### PR TITLE
add resume-after-clear hook for context shedding

### DIFF
--- a/commands/loom.md
+++ b/commands/loom.md
@@ -313,6 +313,17 @@ chmod 444 .claude/state/active_task_graph.json
 ```
 State file stays chmod 444 at rest. Only hooks can write via `StateManager` (temporarily toggles to 644).
 
+### 4e. Context Checkpoint (Recommended)
+
+After populating the task graph and creating the GitHub issue, all planning artifacts are on disk.
+The planning conversation is no longer needed for execution.
+
+**Suggest to user:**
+> "Planning complete. All artifacts on disk. Run `/clear` to shed planning context before execution, or continue in current context."
+
+If user runs `/clear`: SessionStart hook auto-injects execution context. Continue from Phase 5.
+If user continues: Proceed to Phase 5 normally.
+
 ---
 
 ## Phase 5: Execute

--- a/engine/src/cli.ts
+++ b/engine/src/cli.ts
@@ -35,7 +35,7 @@ const KNOWN_HANDLERS: Record<string, Set<string>> = {
     "cleanup-subagent-flag",
   ]),
   "subagent-start": new Set(["mark-subagent-active"]),
-  "session-start": new Set(["cleanup-stale-subagents"]),
+  "session-start": new Set(["cleanup-stale-subagents", "resume-after-clear"]),
   "helper": new Set([
     "complete-wave-gate", "populate-task-graph", "validate-task-graph",
     "store-review-findings", "store-spec-check", "mark-tests-passed",

--- a/engine/src/handlers/session-start/resume-after-clear.ts
+++ b/engine/src/handlers/session-start/resume-after-clear.ts
@@ -7,14 +7,14 @@ import { existsSync } from "node:fs";
 import { StateManager } from "../../state-manager";
 import { TASK_GRAPH_PATH } from "../../config";
 import type { HookHandler } from "../../types";
-import type { TaskGraph, Task } from "../../types";
+import type { TaskGraph, TaskStatus } from "../../types";
 
-function statusIcon(status: string): string {
+function statusIcon(status: TaskStatus): string {
   switch (status) {
-    case "completed": return "done";
+    case "pending":     return "-";
+    case "completed":   return "done";
     case "implemented": return "impl";
-    case "failed": return "FAIL";
-    default: return status;
+    case "failed":      return "FAIL";
   }
 }
 
@@ -22,9 +22,9 @@ function buildContextOutput(state: TaskGraph, loomDir: string): string {
   const maxWave = state.tasks.reduce((m, t) => Math.max(m, t.wave), 0);
   const currentWave = state.current_wave ?? 1;
 
-  const taskRows = state.tasks
+  const taskRows = [...state.tasks]
     .sort((a, b) => a.wave - b.wave || a.id.localeCompare(b.id))
-    .map((t: Task) => `| ${t.id} | ${t.wave} | ${t.agent} | ${statusIcon(t.status)} | ${t.description} |`)
+    .map(t => `| ${t.id} | ${t.wave} | ${t.agent} | ${statusIcon(t.status)} | ${t.description} |`)
     .join("\n");
 
   const lines = [
@@ -59,8 +59,9 @@ function buildContextOutput(state: TaskGraph, loomDir: string): string {
 function resolveLoomDir(): string {
   const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   if (pluginRoot) return pluginRoot;
-  // Fallback: derive from __dirname (engine/src/handlers/session-start/) → 4 levels up
-  return new URL("../../../../", import.meta.url).pathname.replace(/\/$/, "");
+  const derived = new URL("../../../../", import.meta.url).pathname.replace(/\/$/, "");
+  process.stderr.write(`[loom] resume-after-clear: CLAUDE_PLUGIN_ROOT unset, using derived: ${derived}\n`);
+  return derived;
 }
 
 const handler: HookHandler = async (_stdin, _args) => {
@@ -69,9 +70,16 @@ const handler: HookHandler = async (_stdin, _args) => {
   const sm = StateManager.fromPath(TASK_GRAPH_PATH);
   if (!sm) return { kind: "passthrough" };
 
-  const state = sm.load();
+  let state: TaskGraph;
+  try {
+    state = sm.load();
+  } catch (e) {
+    return {
+      kind: "error",
+      message: `[loom] resume-after-clear: corrupt state (${TASK_GRAPH_PATH}): ${(e as Error).message}`,
+    };
+  }
 
-  // Only inject context when in execute phase with populated tasks
   if (state.current_phase !== "execute" || state.tasks.length === 0) {
     return { kind: "passthrough" };
   }

--- a/engine/src/handlers/session-start/resume-after-clear.ts
+++ b/engine/src/handlers/session-start/resume-after-clear.ts
@@ -1,0 +1,86 @@
+/**
+ * Inject execution context into fresh conversation after /clear.
+ * Stdout from SessionStart hooks is auto-injected as context by Claude Code.
+ */
+
+import { existsSync } from "node:fs";
+import { StateManager } from "../../state-manager";
+import { TASK_GRAPH_PATH } from "../../config";
+import type { HookHandler } from "../../types";
+import type { TaskGraph, Task } from "../../types";
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case "completed": return "done";
+    case "implemented": return "impl";
+    case "failed": return "FAIL";
+    default: return status;
+  }
+}
+
+function buildContextOutput(state: TaskGraph, loomDir: string): string {
+  const maxWave = state.tasks.reduce((m, t) => Math.max(m, t.wave), 0);
+  const currentWave = state.current_wave ?? 1;
+
+  const taskRows = state.tasks
+    .sort((a, b) => a.wave - b.wave || a.id.localeCompare(b.id))
+    .map((t: Task) => `| ${t.id} | ${t.wave} | ${t.agent} | ${statusIcon(t.status)} | ${t.description} |`)
+    .join("\n");
+
+  const lines = [
+    "<!-- LOOM RESUME CONTEXT -->",
+    "# Active Loom Session — Execute Phase",
+    "",
+  ];
+
+  if (state.spec_file) lines.push(`**Spec:** ${state.spec_file}`);
+  if (state.plan_file) lines.push(`**Plan:** ${state.plan_file}`);
+  if (state.github_issue && state.github_repo) {
+    lines.push(`**GitHub Issue:** ${state.github_repo}#${state.github_issue}`);
+  } else if (state.github_issue) {
+    lines.push(`**GitHub Issue:** #${state.github_issue}`);
+  }
+  lines.push(`**Current Wave:** ${currentWave} of ${maxWave}`);
+  lines.push("");
+  lines.push("## Task Graph");
+  lines.push("| ID | Wave | Agent | Status | Description |");
+  lines.push("|----|------|-------|--------|-------------|");
+  lines.push(taskRows);
+  lines.push("");
+  lines.push("## Instructions");
+  lines.push(`Read the loom skill at \`${loomDir}/commands/loom.md\`, specifically Phase 5: Execute.`);
+  lines.push(`Spawn all pending wave ${currentWave} tasks in parallel using the Task tool.`);
+  lines.push(`Load impl-agent-context template from \`${loomDir}/commands/templates/impl-agent-context.md\`.`);
+  lines.push("<!-- END LOOM RESUME CONTEXT -->");
+
+  return lines.join("\n");
+}
+
+function resolveLoomDir(): string {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (pluginRoot) return pluginRoot;
+  // Fallback: derive from __dirname (engine/src/handlers/session-start/) → 4 levels up
+  return new URL("../../../../", import.meta.url).pathname.replace(/\/$/, "");
+}
+
+const handler: HookHandler = async (_stdin, _args) => {
+  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "passthrough" };
+
+  const sm = StateManager.fromPath(TASK_GRAPH_PATH);
+  if (!sm) return { kind: "passthrough" };
+
+  const state = sm.load();
+
+  // Only inject context when in execute phase with populated tasks
+  if (state.current_phase !== "execute" || state.tasks.length === 0) {
+    return { kind: "passthrough" };
+  }
+
+  const loomDir = resolveLoomDir();
+  const output = buildContextOutput(state, loomDir);
+  process.stdout.write(output + "\n");
+
+  return { kind: "passthrough" };
+};
+
+export default handler;

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -93,6 +93,15 @@
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/cleanup-stale-subagents.sh"
           }
         ]
+      },
+      {
+        "matcher": "clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/resume-after-clear.sh"
+          }
+        ]
       }
     ]
   }

--- a/hooks/scripts/resume-after-clear.sh
+++ b/hooks/scripts/resume-after-clear.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Inject loom execution context after /clear — stdout goes into fresh conversation
+GRAPH="${CLAUDE_PROJECT_DIR:-.}/.claude/state/active_task_graph.json"
+if [ ! -f "$GRAPH" ]; then
+  cat > /dev/null
+  exit 0
+fi
+
+exec bun ${CLAUDE_PLUGIN_ROOT}/engine/src/cli.ts session-start resume-after-clear

--- a/hooks/scripts/resume-after-clear.sh
+++ b/hooks/scripts/resume-after-clear.sh
@@ -6,4 +6,9 @@ if [ ! -f "$GRAPH" ]; then
   exit 0
 fi
 
-exec bun ${CLAUDE_PLUGIN_ROOT}/engine/src/cli.ts session-start resume-after-clear
+if [ -z "${CLAUDE_PLUGIN_ROOT}" ]; then
+  echo "[loom] resume-after-clear: CLAUDE_PLUGIN_ROOT not set" >&2
+  exit 1
+fi
+
+exec bun "${CLAUDE_PLUGIN_ROOT}/engine/src/cli.ts" session-start resume-after-clear


### PR DESCRIPTION
## Summary

- SessionStart("clear") hook injects loom execution context (spec/plan paths, task graph, wave info) into fresh conversation after `/clear`
- Lets users shed bloated planning context before execute phase — all artifacts are on disk
- No-op when no active state or not yet in execute phase
- Step 4e in loom.md suggests `/clear` after decompose completes

## Files

| File | Change |
|------|--------|
| `hooks/hooks.json` | SessionStart entry with `"matcher": "clear"` |
| `hooks/scripts/resume-after-clear.sh` | Bash shim (follows cleanup-stale-subagents pattern) |
| `engine/src/handlers/session-start/resume-after-clear.ts` | Reads state, writes context table to stdout |
| `engine/src/cli.ts` | Register handler in KNOWN_HANDLERS |
| `commands/loom.md` | Step 4e context checkpoint |

## Test plan

- [ ] Run through decompose, `/clear`, verify stdout context appears in fresh conversation
- [ ] Verify no-op on clean `/clear` (no state file)
- [ ] Verify no-op when state exists but phase != execute
- [ ] Existing tests pass (412/412)