### PR TITLE
fix(hooks): actively grant permission for subagent edits

### DIFF
--- a/engine/src/cli.ts
+++ b/engine/src/cli.ts
@@ -48,6 +48,19 @@ function resultToExit(result: HookResult): never {
   match(result)
     .with({ kind: "allow" }, () => process.exit(0))
     .with({ kind: "passthrough" }, () => process.exit(0))
+    .with({ kind: "permit" }, ({ reason }) => {
+      // Actively grant the permission decision so Claude Code's permission
+      // layer (allowlist + interactive prompt) is bypassed. Required for
+      // background subagents that have no interactive approval path.
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "allow",
+          permissionDecisionReason: reason,
+        },
+      }));
+      process.exit(0);
+    })
     .with({ kind: "block" }, ({ message }) => {
       process.stderr.write(message + "\n");
       process.exit(2);

--- a/engine/src/handlers/pre-tool-use/block-direct-edits.ts
+++ b/engine/src/handlers/pre-tool-use/block-direct-edits.ts
@@ -16,11 +16,18 @@ const handler: HookHandler = async (stdin) => {
 
   if (!FILE_TOOLS.has(input.tool_name)) return { kind: "allow" };
 
-  // Allow if a subagent is active
+  // Allow if a subagent is active.
+  // Use "permit" (active grant) instead of "allow" (passive passthrough) so
+  // Claude Code's permission layer is bypassed entirely — required for
+  // background subagents that have no interactive prompt path and would
+  // otherwise be auto-denied even though loom intends to allow them.
   const activeFile = `${SUBAGENT_DIR}/${input.session_id}.active`;
   try {
     if (existsSync(activeFile) && statSync(activeFile).size > 0) {
-      return { kind: "allow" };
+      return {
+        kind: "permit",
+        reason: "Subagent active under loom orchestration",
+      };
     }
   } catch {}
 

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -6,6 +6,7 @@
 
 export type HookResult =
   | { kind: "allow" }
+  | { kind: "permit"; reason: string }
   | { kind: "block"; message: string }
   | { kind: "error"; message: string }
   | { kind: "passthrough" };


### PR DESCRIPTION
## Summary

- The `block-direct-edits` hook returned passive `{kind: "allow"}` (just exit 0) when a subagent flag was active. That tells Claude Code "the hook has no objection," but the permission layer still runs its normal flow afterwards: allowlist check → user prompt for uncovered paths.
- In **foreground** subagents this is fine — permission prompts surface synchronously. In **background** subagents (which Claude Code auto-promotes for some long-running tasks) there's no interactive path, so the request auto-denies — even though loom intends to allow it.
- Add a `"permit"` `HookResult` variant that emits the standard PreToolUse JSON `{permissionDecision: "allow"}` on stdout, actively granting and bypassing the allowlist + prompt flow.
- `block-direct-edits` now returns `"permit"` (instead of passive `"allow"`) when a subagent is active.

## Why this matters

Without this, users hit a chicken-and-egg: background subagents can't write files, including the one file that would grant them permission (`.claude/settings.local.json`). The workaround is to add a project-wide allowlist via shell before any loom orchestration. With this patch, loom intent is honored regardless of foreground/background mode and no project-side permission rule is required.

## Test plan

- [x] Smoke-test the patched bash shim with the active flag present:
  ```bash
  echo '{"tool_name":"Write","tool_input":{"file_path":"/x"},"session_id":"<id>"}' \
    | CLAUDE_PLUGIN_ROOT=... CLAUDE_PROJECT_DIR=... \
      bash hooks/scripts/block-direct-edits.sh
  ```
  Now prints `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"Subagent active under loom orchestration"}}` and exits 0.
- [x] Foreground sync subagents unchanged (active grant just shortcuts the same outcome).
- [ ] End-to-end: run a `/loom` orchestration where the architecture-agent runs in background; verify it can Write to `.claude/plans/` without an allowlist rule.

## Files

- `engine/src/types.ts` — add `permit` variant to `HookResult`
- `engine/src/cli.ts` — `resultToExit` handles `permit` by writing the JSON decision
- `engine/src/handlers/pre-tool-use/block-direct-edits.ts` — return `permit` when subagent active

🤖 Generated with [Claude Code](https://claude.com/claude-code)