### PR TITLE
feat: emit ADRs via decompose tasks (one ADR per impl agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,11 +391,10 @@ The state file uses a layered protection scheme:
 ### Task Status Transitions
 
 ```
-pending -------> in_progress     (agent spawned)
-in_progress ---> implemented     (agent completes, test evidence extracted)
-in_progress ---> failed          (agent crash, retry_count incremented)
-failed --------> in_progress     (auto-retry, max 2 attempts)
-implemented ---> completed       (wave gate passed)
+pending -----> implemented     (agent completes, test evidence extracted)
+pending -----> failed          (agent crash; retry_count incremented)
+failed ------> pending         (auto-retry, max 2 attempts)
+implemented -> completed       (wave gate passed)
 ```
 
 ### State File Lifecycle
@@ -421,14 +420,14 @@ engine/
 │   ├── state-manager.ts     # Atomic state file read/write with locking
 │   ├── phase-init.ts        # Initial state resolution from skip flags
 │   ├── handlers/
-│   │   ├── pre-tool-use/    # Validation hooks (7 handlers)
-│   │   ├── subagent-stop/   # Phase/status/review hooks (6 handlers)
-│   │   ├── subagent-start/  # Lifecycle tracking (1 handler)
-│   │   ├── session-start/   # Initialization hooks (2 handlers)
-│   │   └── helpers/         # Whitelisted helper scripts (11 handlers)
+│   │   ├── pre-tool-use/    # Validation hooks
+│   │   ├── subagent-stop/   # Phase/status/review hooks
+│   │   ├── subagent-start/  # Lifecycle tracking
+│   │   ├── session-start/   # Initialization + resume-after-clear hooks
+│   │   └── helpers/         # Whitelisted helper scripts + utility modules
 │   ├── parsers/             # Extract structured data from agent transcripts
 │   └── utils/               # Git operations, file locking, file search
-└── tests/                   # 28 test files (unit, property-based, e2e)
+└── tests/                   # Unit, property-based, and e2e tests
 ```
 
 ### CLI Entry Point
@@ -468,14 +467,14 @@ The engine includes parsers for extracting structured data from agent output:
 
 ### Key Constants (`engine/src/config.ts`)
 
-| Constant | Value | Purpose |
-|----------|-------|---------|
-| `CLARIFY_THRESHOLD` | 3 | Markers above this trigger mandatory clarify phase |
-| `PHASE_ORDER` | 8 phases | Valid phase sequence |
-| `PHASE_AGENT_MAP` | 6 entries | Maps phase agents to their phase |
-| `IMPL_AGENTS` | 6 agents | Implementation agents for execute phase |
-| `REVIEW_SUB_AGENTS` | 6 agents | Review agents for wave gates |
-| `WHITELISTED_HELPERS` | 8 scripts | Scripts allowed to write to state file |
+| Constant | Purpose |
+|----------|---------|
+| `CLARIFY_THRESHOLD` | Markers above this trigger mandatory clarify phase (default: 3) |
+| `PHASE_ORDER` | Valid phase sequence |
+| `PHASE_AGENT_MAP` | Maps each phase to the agent that runs it |
+| `IMPL_AGENTS` | Implementation agents allowed to spawn during the execute phase |
+| `REVIEW_SUB_AGENTS` | Review agents whose findings feed wave gates |
+| `WHITELISTED_HELPERS` | Helper scripts allowed to write to the state file |
 
 ### Plan Limits
 
@@ -563,15 +562,15 @@ The test suite includes 28 test files covering:
 loom/
 ├── .claude-plugin/
 │   └── plugin.json            # Plugin metadata
-├── agents/                     # Agent definitions (22 .md files)
+├── agents/                     # Agent definitions
 ├── commands/                   # Skill definitions
-│   └── templates/              # Phase prompt templates (7 files)
+│   └── templates/              # Phase prompt templates
 ├── engine/                     # TypeScript hook engine
 │   ├── src/                    # Source code
 │   └── tests/                  # Test suite
 ├── hooks/
 │   ├── hooks.json              # Hook configuration
-│   └── scripts/                # Shell shims (11 files)
+│   └── scripts/                # Shell shims
 └── references/                 # Spec and plan templates
 ```
 

--- a/agents/adr-writer-agent.md
+++ b/agents/adr-writer-agent.md
@@ -11,7 +11,7 @@ Find the loom plugin directory (`ls -d "$HOME/.claude/plugins/cache/plugins/loom
 
 Your task's `plan_context` contains an AD seed (Choice / Why / Rejected) from the plan's `## Architectural Decisions` section. Expand it into a full ADR:
 
-- **Status:** `Accepted` (the decision has been made and the plan is approved).
+- **Status:** `Accepted` (set at write-time — ADR runs after impl waves so the decision has shipped).
 - **Context:** Why the decision was needed. Forces at play. State the problem, not the solution. Use the spec and plan as context.
 - **Options Considered:** At least 2 numbered options with Pros/Cons. Use the AD seed's Rejected list as a starting point. If the choice was forced (no real alternatives), say so explicitly but still document the decision.
 - **Decision:** One-line statement of the chosen option, then concrete detail (architecture, components, file paths, invariants).

--- a/agents/adr-writer-agent.md
+++ b/agents/adr-writer-agent.md
@@ -1,0 +1,26 @@
+---
+name: adr-writer-agent
+description: Use as a subagent for writing a single Architecture Decision Record. One ADR per task. Produces document, not code.
+model: opus
+color: blue
+---
+
+You write a single Architecture Decision Record.
+
+Find the loom plugin directory (`ls -d "$HOME/.claude/plugins/cache/plugins/loom"/*/` — use latest), then read `references/adr-template.md` from it. Follow that template exactly.
+
+Your task's `plan_context` contains an AD seed (Choice / Why / Rejected) from the plan's `## Architectural Decisions` section. Expand it into a full ADR:
+
+- **Status:** `Accepted` (the decision has been made and the plan is approved).
+- **Context:** Why the decision was needed. Forces at play. State the problem, not the solution. Use the spec and plan as context.
+- **Options Considered:** At least 2 numbered options with Pros/Cons. Use the AD seed's Rejected list as a starting point. If the choice was forced (no real alternatives), say so explicitly but still document the decision.
+- **Decision:** One-line statement of the chosen option, then concrete detail (architecture, components, file paths, invariants).
+- **Consequences:** Positive and Negative bullet lists. Be honest about tradeoffs and risks accepted.
+
+Write to the file path in your task's `file_list`. The path includes the pre-allocated ADR number (`docs/adr/NNNN-slug.md`) — do not change it.
+
+Constraints:
+- Write exactly one ADR per invocation.
+- Do not write code.
+- Do not create or modify files outside the path in `file_list`.
+- Do not commit — the wave-gate handles commits.

--- a/commands/templates/impl-agent-context.md
+++ b/commands/templates/impl-agent-context.md
@@ -6,7 +6,7 @@ Template for spawning implementation agents during Execute phase. All template v
 
 ## !! MANDATORY FINAL STEP — READ THIS FIRST !!
 
-**Your LAST action before finishing MUST be running tests via the Bash tool.**
+**Your LAST action before finishing MUST be running tests via the Bash tool — UNLESS this is a docs/config-only task (your task graph entry has `new_tests_required: false`, e.g. ADR writing, migrations, config tweaks). For those, skip the test run; the engine recognizes `new_tests_required: false` and will not block the wave gate on missing test evidence.**
 
 ```
 bun test          # TypeScript/Bun projects
@@ -17,10 +17,10 @@ pytest            # Python projects
 ```
 
 A hook reads your transcript and extracts test evidence ONLY from Bash tool_result blocks.
-If you do not run tests via Bash, `tests_passed = false` and the wave gate FAILS.
+If your task DOES require tests and you do not run them via Bash, `tests_passed = false` and the wave gate FAILS.
 Writing tests without executing them counts as failure.
 
-**Do NOT finish without Bash test output showing pass markers (e.g., "X passing", "0 fail", "BUILD SUCCESS").**
+**For test-required tasks: do NOT finish without Bash test output showing pass markers (e.g., "X passing", "0 fail", "BUILD SUCCESS").**
 
 ---
 
@@ -71,6 +71,6 @@ Available at: {plan_file_path}
 
 1. Read the plan file and understand scope
 2. Implement code following the plan's patterns
-3. Write NEW tests (hook git-diffs for @Test, it(, test(, describe( patterns — no new tests = wave blocked)
-4. **Run tests via Bash tool** — fix failures, re-run until 0 failures
+3. Write NEW tests (hook git-diffs for @Test, it(, test(, describe( patterns — no new tests = wave blocked) — **skip for docs/config-only tasks where `new_tests_required: false`**
+4. **Run tests via Bash tool** — fix failures, re-run until 0 failures — **skip for docs/config-only tasks**
 5. Only then are you done

--- a/commands/templates/phase-architecture.md
+++ b/commands/templates/phase-architecture.md
@@ -72,39 +72,7 @@ Find the loom plugin directory (`ls -d "$HOME/.claude/plugins/cache/plugins/loom
 
 Commit: `git add .claude/plans/ && git commit -m "plan: {date_slug}"`
 
-### 6. Emit Architecture Decision Records (ADRs)
-
-For each significant decision made in this design, write an ADR to `docs/adr/`.
-
-**Trigger an ADR when ANY of the following:**
-- You evaluated 2+ alternatives in Step 3 and chose one (record the tradeoff)
-- The design introduces a new dependency, framework, or runtime
-- The design changes the data model (new tables, schema changes)
-- The design establishes a cross-cutting pattern (error model, logging, auth, retention)
-- The design locks in a non-obvious constraint or invariant
-
-**Skip ADRs for:**
-- Trivial naming or file-placement choices
-- Decisions fully determined by existing patterns
-
-**Filename:** `docs/adr/{NNNN}-{slug}.md` where:
-- `{NNNN}` = max existing ADR number + 1, zero-padded to 4 digits. Find via:
-  ```bash
-  ls docs/adr/ 2>/dev/null | grep -oE '^[0-9]{4}' | sort -n | tail -1
-  ```
-  If no ADRs exist yet, start at `0001`.
-- `{slug}` = kebab-case topic (e.g., `eval-framework`).
-
-**Structure:** Find the loom plugin directory (same approach as Step 5), then read `references/adr-template.md` and follow it exactly. Substitute all `{...}` placeholders. Status defaults to `Accepted`.
-
-**Numbering across multiple ADRs in this run:** When emitting N ADRs, allocate consecutive numbers — do NOT re-scan between writes.
-
-**Plan-alignment loop-back:** If re-running architecture with gap context, edit existing ADRs in place for changed decisions; create new ones for surfaced decisions; do not duplicate unchanged ADRs.
-
-**Commit:** Single commit for the batch:
-```bash
-git add docs/adr/ && git commit -m "adr: add ADRs for {date_slug}"
-```
+**ADR seeds:** For decisions worth recording as ADRs (2+ alternatives evaluated, new dependency, data model change, cross-cutting pattern, or non-obvious invariant), ensure each is captured as a `### AD-N: {Title}` block in the plan's `## Architectural Decisions` section per `references/plan-template.md`. Decompose will turn each AD into a dedicated ADR-writing task in the final wave. Skip ADs for trivial naming or file-placement choices. Do NOT write ADRs yourself in this phase.
 
 ---
 
@@ -121,7 +89,6 @@ git add docs/adr/ && git commit -m "adr: add ADRs for {date_slug}"
 
 - Path to created plan file
 - Implementation phases identified (count + names)
-- Key architectural decisions with rationale
-- List of ADRs emitted (paths) — empty list is fine if no decisions met the trigger criteria
+- Key architectural decisions with rationale (captured as `### AD-N` blocks in the plan)
 
 The architecture-agent has the `architecture-tech-lead` skill preloaded which provides FP, DDD, testability, and stack-specific domain knowledge. Use that knowledge to **design**, not to **review**.

--- a/commands/templates/phase-architecture.md
+++ b/commands/templates/phase-architecture.md
@@ -72,6 +72,40 @@ Find the loom plugin directory (`ls -d "$HOME/.claude/plugins/cache/plugins/loom
 
 Commit: `git add .claude/plans/ && git commit -m "plan: {date_slug}"`
 
+### 6. Emit Architecture Decision Records (ADRs)
+
+For each significant decision made in this design, write an ADR to `docs/adr/`.
+
+**Trigger an ADR when ANY of the following:**
+- You evaluated 2+ alternatives in Step 3 and chose one (record the tradeoff)
+- The design introduces a new dependency, framework, or runtime
+- The design changes the data model (new tables, schema changes)
+- The design establishes a cross-cutting pattern (error model, logging, auth, retention)
+- The design locks in a non-obvious constraint or invariant
+
+**Skip ADRs for:**
+- Trivial naming or file-placement choices
+- Decisions fully determined by existing patterns
+
+**Filename:** `docs/adr/{NNNN}-{slug}.md` where:
+- `{NNNN}` = max existing ADR number + 1, zero-padded to 4 digits. Find via:
+  ```bash
+  ls docs/adr/ 2>/dev/null | grep -oE '^[0-9]{4}' | sort -n | tail -1
+  ```
+  If no ADRs exist yet, start at `0001`.
+- `{slug}` = kebab-case topic (e.g., `eval-framework`).
+
+**Structure:** Find the loom plugin directory (same approach as Step 5), then read `references/adr-template.md` and follow it exactly. Substitute all `{...}` placeholders. Status defaults to `Accepted`.
+
+**Numbering across multiple ADRs in this run:** When emitting N ADRs, allocate consecutive numbers — do NOT re-scan between writes.
+
+**Plan-alignment loop-back:** If re-running architecture with gap context, edit existing ADRs in place for changed decisions; create new ones for surfaced decisions; do not duplicate unchanged ADRs.
+
+**Commit:** Single commit for the batch:
+```bash
+git add docs/adr/ && git commit -m "adr: add ADRs for {date_slug}"
+```
+
 ---
 
 ## What NOT to Do
@@ -88,5 +122,6 @@ Commit: `git add .claude/plans/ && git commit -m "plan: {date_slug}"`
 - Path to created plan file
 - Implementation phases identified (count + names)
 - Key architectural decisions with rationale
+- List of ADRs emitted (paths) — empty list is fine if no decisions met the trigger criteria
 
 The architecture-agent has the `architecture-tech-lead` skill preloaded which provides FP, DDD, testability, and stack-specific domain knowledge. Use that knowledge to **design**, not to **review**.

--- a/commands/templates/phase-decompose.md
+++ b/commands/templates/phase-decompose.md
@@ -29,6 +29,7 @@ Read the spec and plan, then decompose into parallel task graph.
 | security-agent | security, auth, jwt, oauth, vulnerability |
 | dotfiles-agent | nix, nixos, home-manager, sops |
 | frontend-agent | frontend, ui, react, next.js, component — **writes tests too** |
+| adr-writer-agent | write a single ADR document — used for tasks expanding plan AD-N entries (one task per AD) |
 
 Fallback: `general-purpose`
 
@@ -50,6 +51,19 @@ Fallback: `general-purpose`
    - Wave 2: Tasks depending on Wave 1
    - Wave N: Tasks depending on Wave N-1
    - Dependencies MUST be in earlier waves
+6. **ADR tasks:** For each `### AD-N: {Title}` block in plan.md's `## Architectural Decisions` section, create exactly one task:
+   - `agent`: `adr-writer-agent`
+   - `wave`: highest wave number used by other tasks (final wave — ADRs document what shipped)
+   - `depends_on`: all impl task IDs from prior waves
+   - `new_tests_required`: `false`
+   - `plan_context`: the full AD-N block text (Choice / Why / Rejected verbatim)
+   - `file_list`: `["docs/adr/{NNNN}-{slug}.md"]` where:
+     - `{NNNN}` = pre-allocated. Read existing `docs/adr/` (use Glob/Read), find max 4-digit prefix, increment for first AD, then sequential for subsequent ADs in plan order. If no ADRs exist, start at `0001`.
+     - `{slug}` = kebab-case from AD title (e.g., "Hono framework choice" → `hono-framework-choice`). Append `-2`, `-3` etc. on title collision within this run.
+   - `description`: `"Write ADR-{NNNN}: {AD title}"`
+   - `spec_anchors`: any FR/SC/US referenced in the AD's Why text (can be empty `[]`)
+
+   Skip ADR task creation if plan has no `## Architectural Decisions` section or it's empty.
 
 ---
 

--- a/commands/templates/phase-decompose.md
+++ b/commands/templates/phase-decompose.md
@@ -53,7 +53,7 @@ Fallback: `general-purpose`
    - Dependencies MUST be in earlier waves
 6. **ADR tasks:** For each `### AD-N: {Title}` block in plan.md's `## Architectural Decisions` section, create exactly one task:
    - `agent`: `adr-writer-agent`
-   - `wave`: highest wave number used by other tasks (final wave — ADRs document what shipped)
+   - `wave`: `(max wave used by impl tasks) + 1` — ADRs run in a dedicated final wave AFTER all impl waves so they can document what actually shipped. Rule 5 requires dependencies be in earlier waves; ADRs depend on all impl tasks, so they cannot share a wave with any of them.
    - `depends_on`: all impl task IDs from prior waves
    - `new_tests_required`: `false`
    - `plan_context`: the full AD-N block text (Choice / Why / Rejected verbatim)

--- a/commands/templates/phase-decompose.md
+++ b/commands/templates/phase-decompose.md
@@ -54,7 +54,7 @@ Fallback: `general-purpose`
 6. **ADR tasks:** For each `### AD-N: {Title}` block in plan.md's `## Architectural Decisions` section, create exactly one task:
    - `agent`: `adr-writer-agent`
    - `wave`: `(max wave used by impl tasks) + 1` — ADRs run in a dedicated final wave AFTER all impl waves so they can document what actually shipped. Rule 5 requires dependencies be in earlier waves; ADRs depend on all impl tasks, so they cannot share a wave with any of them.
-   - `depends_on`: all impl task IDs from prior waves
+   - `depends_on`: all impl task IDs from prior waves (convention — not enforced by `validate-task-graph`; the wave-ordering rule is what gates execution)
    - `new_tests_required`: `false`
    - `plan_context`: the full AD-N block text (Choice / Why / Rejected verbatim)
    - `file_list`: `["docs/adr/{NNNN}-{slug}.md"]` where:

--- a/engine/src/cli.ts
+++ b/engine/src/cli.ts
@@ -10,6 +10,7 @@ import { match } from "ts-pattern";
 import { writeFileSync, chmodSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { HookResult, HookHandler } from "./types";
+import { nonEmptyMessage } from "./types";
 import { resolveInitialState } from "./phase-init";
 
 // Eagerly buffer stdin before any async work (bun drains piped data during dynamic imports)
@@ -49,11 +50,11 @@ function resultToExit(result: HookResult): never {
     .with({ kind: "allow" }, () => process.exit(0))
     .with({ kind: "passthrough" }, () => process.exit(0))
     .with({ kind: "block" }, ({ message }) => {
-      process.stderr.write(message + "\n");
+      process.stderr.write(nonEmptyMessage(message) + "\n");
       process.exit(2);
     })
     .with({ kind: "error" }, ({ message }) => {
-      process.stderr.write(message + "\n");
+      process.stderr.write(nonEmptyMessage(message) + "\n");
       process.exit(1);
     })
     .exhaustive();

--- a/engine/src/config.ts
+++ b/engine/src/config.ts
@@ -33,6 +33,7 @@ export const IMPL_AGENTS = new Set([
   "frontend-agent",
   "security-agent",
   "dotfiles-agent",
+  "adr-writer-agent",
   "general-purpose",
 ]);
 

--- a/engine/src/config.ts
+++ b/engine/src/config.ts
@@ -26,7 +26,11 @@ export const PHASE_AGENT_MAP: Record<string, Phase> = {
   "decompose-agent": "decompose",
 };
 
-/** Impl agents → all map to "execute" phase */
+/** Impl agents → all map to "execute" phase.
+ *  Note: agent identifiers are intentionally `string` (no brand). Bun runs
+ *  in transpile-only mode, so a TS brand would not enforce anything at
+ *  runtime; the real boundary check lives in validate-task-graph.ts via
+ *  KNOWN_AGENTS.has(agent). */
 export const IMPL_AGENTS = new Set([
   "code-implementer-agent",
   "ts-test-agent",

--- a/engine/src/handlers/helpers/complete-wave-gate.ts
+++ b/engine/src/handlers/helpers/complete-wave-gate.ts
@@ -17,38 +17,44 @@ function parseWaveArg(args: string[]): number | null {
   return null;
 }
 
-interface GateCheck {
-  passed: boolean;
-  message: string;
+export type GateCheck =
+  | { passed: true;  summary: string }
+  | { passed: false; reason: string };
+
+const pass = (summary: string): GateCheck => ({ passed: true, summary });
+const fail = (reason: string): GateCheck => ({ passed: false, reason });
+
+/** Render a check for stderr output. */
+export function gateCheckMessage(c: GateCheck): string {
+  return c.passed ? c.summary : c.reason;
 }
 
-/** Check 1: All tasks have test evidence */
+/** Check 1: All tasks have test evidence (skipped for tasks declaring no tests required) */
 export function checkTestEvidence(tasks: Task[]): GateCheck {
-  const missing = tasks.filter((t) => !t.tests_passed);
+  const missing = tasks.filter((t) => t.new_tests_required !== false && !t.tests_passed);
   if (missing.length > 0) {
-    return {
-      passed: false,
-      message: `FAILED: Not all tasks have test evidence.\n  Missing: ${missing.map((t) => t.id).join(", ")}`,
-    };
+    return fail(`FAILED: Not all tasks have test evidence.\n  Missing: ${missing.map((t) => t.id).join(", ")}`);
   }
-  const lines = tasks.map((t) => `     ${t.id}: ${t.test_evidence ?? "evidence present"}`);
-  return { passed: true, message: `1. Test evidence verified (${tasks.length}/${tasks.length} tasks):\n${lines.join("\n")}` };
+  const lines = tasks.map((t) => {
+    const evidence = t.new_tests_required === false
+      ? "not required"
+      : (t.test_evidence ?? "evidence present");
+    return `     ${t.id}: ${evidence}`;
+  });
+  return pass(`1. Test evidence verified (${tasks.length}/${tasks.length} tasks):\n${lines.join("\n")}`);
 }
 
 /** Check 1b: New tests written or not required */
 export function checkNewTests(tasks: Task[]): GateCheck {
   const missing = tasks.filter((t) => t.new_tests_required !== false && !t.new_tests_written);
   if (missing.length > 0) {
-    return {
-      passed: false,
-      message: `FAILED: Not all tasks satisfied new-test requirement.\n  Missing: ${missing.map((t) => t.id).join(", ")}`,
-    };
+    return fail(`FAILED: Not all tasks satisfied new-test requirement.\n  Missing: ${missing.map((t) => t.id).join(", ")}`);
   }
   const lines = tasks.map((t) => {
     const evidence = t.new_test_evidence ?? (t.new_tests_required === false ? "not required" : "new tests present");
     return `     ${t.id}: ${evidence}`;
   });
-  return { passed: true, message: `   New tests verified (${tasks.length}/${tasks.length} tasks):\n${lines.join("\n")}` };
+  return pass(`   New tests verified (${tasks.length}/${tasks.length} tasks):\n${lines.join("\n")}`);
 }
 
 /** Check 2: All tasks reviewed */
@@ -56,32 +62,29 @@ export function checkReviews(tasks: Task[]): GateCheck {
   const reviewed = tasks.filter((t) => t.review_status === "passed" || t.review_status === "blocked");
   if (reviewed.length !== tasks.length) {
     const unreviewed = tasks.filter((t) => !t.review_status || t.review_status === "pending").map((t) => t.id);
-    const failed = tasks.filter((t) => t.review_status === "evidence_capture_failed").map((t) => t.id);
+    const failedReview = tasks.filter((t) => t.review_status === "evidence_capture_failed").map((t) => t.id);
     const parts = ["FAILED: Not all tasks have been reviewed."];
-    if (failed.length > 0) parts.push(`  Evidence capture failed: ${failed.join(", ")}`);
+    if (failedReview.length > 0) parts.push(`  Evidence capture failed: ${failedReview.join(", ")}`);
     if (unreviewed.length > 0) parts.push(`  Unreviewed: ${unreviewed.join(", ")}`);
-    return { passed: false, message: parts.join("\n") };
+    return fail(parts.join("\n"));
   }
   const lines = tasks.map((t) => `     ${t.id}: ${t.review_status}`);
-  return { passed: true, message: `2. Reviews verified (${tasks.length}/${tasks.length} tasks):\n${lines.join("\n")}` };
+  return pass(`2. Reviews verified (${tasks.length}/${tasks.length} tasks):\n${lines.join("\n")}`);
 }
 
 /** Check 3: Spec alignment */
 export function checkSpecAlignment(state: TaskGraph, wave: number): GateCheck {
   if (!state.spec_check) {
-    return { passed: true, message: "3. Spec alignment: skipped (no spec-check data)." };
+    return pass("3. Spec alignment: skipped (no spec-check data).");
   }
   if (state.spec_check.wave !== wave) {
-    return { passed: false, message: `FAILED: Spec alignment was run for wave ${state.spec_check.wave}, not ${wave}. Re-run /spec-check for wave ${wave}.` };
+    return fail(`FAILED: Spec alignment was run for wave ${state.spec_check.wave}, not ${wave}. Re-run /spec-check for wave ${wave}.`);
   }
   if ((state.spec_check.critical_count ?? 0) > 0) {
     const findings = (state.spec_check.critical_findings ?? []).map((f) => `  - ${f}`).join("\n");
-    return {
-      passed: false,
-      message: `FAILED: Spec alignment has ${state.spec_check.critical_count} critical findings.\n${findings}`,
-    };
+    return fail(`FAILED: Spec alignment has ${state.spec_check.critical_count} critical findings.\n${findings}`);
   }
-  return { passed: true, message: `3. Spec alignment verified (verdict: ${state.spec_check.verdict}).` };
+  return pass(`3. Spec alignment verified (verdict: ${state.spec_check.verdict}).`);
 }
 
 /** Check 4: No critical code review findings */
@@ -95,9 +98,9 @@ export function checkCriticalFindings(tasks: Task[]): GateCheck {
       .filter((t) => (t.critical_findings?.filter(f => f.trim() !== '').length ?? 0) > 0)
       .map((t) => `  ${t.id}: ${t.critical_findings!.filter(f => f.trim() !== '').join(", ")}`)
       .join("\n");
-    return { passed: false, message: `FAILED: ${totalCritical} critical code review findings.\n${details}` };
+    return fail(`FAILED: ${totalCritical} critical code review findings.\n${details}`);
   }
-  return { passed: true, message: "4. No critical code review findings." };
+  return pass("4. No critical code review findings.");
 }
 
 /** Update GitHub issue checkboxes */
@@ -116,7 +119,9 @@ function updateGitHubIssue(state: TaskGraph, taskIds: string[]): void {
 
     execSync(`gh issue edit ${issue} ${repoFlag} --body-file -`, { input: updated, stdio: ["pipe", "pipe", "pipe"] });
     process.stderr.write(`Updated checkboxes in issue #${issue}\n`);
-  } catch {}
+  } catch (e) {
+    process.stderr.write(`WARNING: Failed to update GH issue #${issue} checkboxes: ${(e as Error).message}\n`);
+  }
 }
 
 /** Compute next wave from actual wave numbers (handles non-contiguous waves) */
@@ -168,17 +173,15 @@ export function generateWaveGateSummary(
   return lines.join('\n');
 }
 
-/** Post GitHub comment summarizing wave gate results */
-async function postWaveGateSummary(mgr: StateManager, waveArg: number | null): Promise<void> {
-  const state = mgr.load();
-  const currentWave = waveArg ?? state.current_wave ?? 1;
+/** Post GitHub comment summarizing wave gate results.
+ *  Takes a snapshot of state captured under the update lock to avoid a second read. */
+function postWaveGateSummary(state: TaskGraph, completedWave: number): void {
   const githubIssue = state.github_issue;
-
   if (!githubIssue) return;
 
   try {
-    const waveTasks = state.tasks.filter((t) => t.wave === currentWave);
-    const body = generateWaveGateSummary(currentWave, waveTasks, state.spec_check);
+    const waveTasks = state.tasks.filter((t) => t.wave === completedWave);
+    const body = generateWaveGateSummary(completedWave, waveTasks, state.spec_check);
 
     const repoFlag = state.github_repo ? `--repo ${state.github_repo}` : "";
     execSync(`gh issue comment ${githubIssue} ${repoFlag} --body-file -`, {
@@ -186,7 +189,7 @@ async function postWaveGateSummary(mgr: StateManager, waveArg: number | null): P
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 15000,
     });
-    process.stderr.write(`Posted wave ${currentWave} summary to issue #${githubIssue}\n`);
+    process.stderr.write(`Posted wave ${completedWave} summary to issue #${githubIssue}\n`);
   } catch (e) {
     // Non-blocking — don't fail the gate on comment failure
     process.stderr.write(`WARNING: Failed to post GH comment: ${(e as Error).message}\n`);
@@ -203,68 +206,79 @@ const handler: HookHandler = async (_stdin, args) => {
   let errorMessage: string | null = null;
   let taskIds: string[] = [];
   let nextWave: number | null = null;
+  let completedWave: number = waveArg ?? 1;
   let githubState: { issue?: number; repo?: string } = {};
+  let snapshot: TaskGraph | null = null;
 
-  await mgr.update((s) => {
-    const wave = waveArg ?? s.current_wave ?? 1;
-    const waveTasks = s.tasks.filter((t) => t.wave === wave);
+  try {
+    await mgr.update((s) => {
+      const wave = waveArg ?? s.current_wave ?? 1;
+      completedWave = wave;
+      const waveTasks = s.tasks.filter((t) => t.wave === wave);
 
-    process.stderr.write(`Completing wave ${wave} gate...\n\n`);
+      process.stderr.write(`Completing wave ${wave} gate...\n\n`);
 
-    // Run all checks on locked state
-    const checks = [
-      checkTestEvidence(waveTasks),
-      checkNewTests(waveTasks),
-      checkReviews(waveTasks),
-      checkSpecAlignment(s, wave),
-      checkCriticalFindings(waveTasks),
-    ];
+      // Run all checks on locked state
+      const checks = [
+        checkTestEvidence(waveTasks),
+        checkNewTests(waveTasks),
+        checkReviews(waveTasks),
+        checkSpecAlignment(s, wave),
+        checkCriticalFindings(waveTasks),
+      ];
 
-    for (const check of checks) {
-      process.stderr.write(check.message + "\n");
-      if (!check.passed) {
-        errorMessage = check.message;
-        return s; // Return state unchanged
+      for (const check of checks) {
+        process.stderr.write(gateCheckMessage(check) + "\n");
+        if (!check.passed) {
+          errorMessage = check.reason;
+          return s; // Return state unchanged
+        }
       }
-    }
 
-    process.stderr.write("\nAll checks passed. Advancing...\n");
+      process.stderr.write("\nAll checks passed. Advancing...\n");
 
-    taskIds = waveTasks.map((t) => t.id);
-    githubState = { issue: s.github_issue, repo: s.github_repo };
+      taskIds = waveTasks.map((t) => t.id);
+      githubState = { issue: s.github_issue, repo: s.github_repo };
 
-    // Compute next wave from actual wave numbers
-    nextWave = computeNextWave(s.tasks, wave);
+      // Compute next wave from actual wave numbers
+      nextWave = computeNextWave(s.tasks, wave);
 
-    const defaultGate: WaveGate = { impl_complete: false, tests_passed: null, reviews_complete: false, blocked: false };
+      const defaultGate: WaveGate = { impl_complete: false, tests_passed: null, reviews_complete: false, blocked: false };
 
-    // Build updated state atomically
-    const updated: TaskGraph = {
-      ...s,
-      tasks: s.tasks.map((t) =>
-        t.wave === wave
-          ? { ...t, status: "completed" as const, review_status: "passed" as const }
-          : t
-      ),
-      wave_gates: {
-        ...s.wave_gates,
-        [String(wave)]: {
-          ...(s.wave_gates[String(wave)] ?? defaultGate),
-          tests_passed: true,
-          reviews_complete: true,
-          blocked: false,
-        },
-        ...(nextWave != null ? {
-          [String(nextWave)]: {
-            ...(s.wave_gates[String(nextWave)] ?? defaultGate),
+      // Build updated state atomically
+      const updated: TaskGraph = {
+        ...s,
+        tasks: s.tasks.map((t) =>
+          t.wave === wave
+            ? { ...t, status: "completed" as const, review_status: "passed" as const }
+            : t
+        ),
+        wave_gates: {
+          ...s.wave_gates,
+          [String(wave)]: {
+            ...(s.wave_gates[String(wave)] ?? defaultGate),
+            tests_passed: true,
+            reviews_complete: true,
+            blocked: false,
           },
-        } : {}),
-      },
-      ...(nextWave != null ? { current_wave: nextWave } : {}),
-    };
+          ...(nextWave != null ? {
+            [String(nextWave)]: {
+              ...(s.wave_gates[String(nextWave)] ?? defaultGate),
+            },
+          } : {}),
+        },
+        ...(nextWave != null ? { current_wave: nextWave } : {}),
+      };
 
-    return updated;
-  });
+      snapshot = updated;
+      return updated;
+    });
+  } catch (e) {
+    return {
+      kind: "error",
+      message: `[loom] complete-wave-gate: failed to persist state for wave ${completedWave}: ${(e as Error).message}`,
+    };
+  }
 
   if (errorMessage) {
     return { kind: "error", message: errorMessage };
@@ -281,8 +295,10 @@ const handler: HookHandler = async (_stdin, args) => {
     process.stderr.write("\n=== All waves complete! ===\nRun /loom --complete to finalize.\n");
   }
 
-  // Post GitHub comment with wave summary
-  await postWaveGateSummary(mgr, waveArg);
+  // Post GitHub comment with wave summary using snapshot from inside the lock
+  if (snapshot) {
+    postWaveGateSummary(snapshot, completedWave);
+  }
 
   return { kind: "passthrough" };
 };

--- a/engine/src/handlers/helpers/populate-task-graph.ts
+++ b/engine/src/handlers/helpers/populate-task-graph.ts
@@ -65,7 +65,7 @@ const handler: HookHandler = async (stdin, args) => {
 
   // Validate decompose output before merging
   const validation = validateFull(decompose as unknown as Record<string, unknown>);
-  if (!validation.valid) {
+  if (!validation.ok) {
     if (fix) {
       decompose = JSON.parse(fixFull(decompose as unknown as Record<string, unknown>)) as DecomposeInput;
       process.stderr.write(`Auto-fixed ${validation.errors.length} issues\n`);

--- a/engine/src/handlers/helpers/validate-task-graph.ts
+++ b/engine/src/handlers/helpers/validate-task-graph.ts
@@ -17,7 +17,7 @@ interface ValidationResult {
 
 const VALID_PHASES = new Set<string>(PHASE_ORDER);
 
-const NO_TEST_KEYWORDS = /migration|config|schema|rename|bump|version|refactor|cleanup|typo|docs|interface|documentation|changelog|readme|ci|cd|pipeline|deploy|→|->|styling|css|formatting/i;
+const NO_TEST_KEYWORDS = /migration|config|schema|rename|bump|version|refactor|cleanup|typo|docs|interface|documentation|changelog|readme|ci|cd|pipeline|deploy|→|->|styling|css|formatting|adr/i;
 
 /** Validate minimal phase-tracking graph (no tasks) */
 export function validateMinimal(json: Record<string, unknown>): ValidationResult {

--- a/engine/src/handlers/helpers/validate-task-graph.ts
+++ b/engine/src/handlers/helpers/validate-task-graph.ts
@@ -9,11 +9,12 @@ import { match } from "ts-pattern";
 import type { HookHandler, Phase, TaskGraph } from "../../types";
 import { PHASE_ORDER, KNOWN_AGENTS } from "../../config";
 
-interface ValidationResult {
-  valid: boolean;
-  errors: string[];
-  fixed?: string; // corrected JSON if --fix
-}
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; errors: readonly string[] };
+
+function ok(): ValidationResult { return { ok: true }; }
+function fail(errors: string[]): ValidationResult { return { ok: false, errors }; }
 
 const VALID_PHASES = new Set<string>(PHASE_ORDER);
 
@@ -34,7 +35,7 @@ export function validateMinimal(json: Record<string, unknown>): ValidationResult
   if (!("spec_file" in json)) errors.push("Missing required field: spec_file");
   if (!("plan_file" in json)) errors.push("Missing required field: plan_file");
 
-  return { valid: errors.length === 0, errors };
+  return errors.length === 0 ? ok() : fail(errors);
 }
 
 /** Fix minimal graph — preserve valid fields, default invalid ones */
@@ -62,7 +63,7 @@ export function validateFull(json: Record<string, unknown>): ValidationResult {
   const tasks = json.tasks;
   if (!Array.isArray(tasks)) {
     errors.push("'tasks' must be an array");
-    return { valid: false, errors };
+    return fail(errors);
   }
 
   if (tasks.length === 0) errors.push("'tasks' array is empty");
@@ -127,7 +128,28 @@ export function validateFull(json: Record<string, unknown>): ValidationResult {
     }
   }
 
-  return { valid: errors.length === 0, errors };
+  // ADR tasks must be in the highest wave so they document what already shipped.
+  const adrTasks = tasks.filter((t: Record<string, unknown>) => t.agent === "adr-writer-agent");
+  if (adrTasks.length > 0 && waves.length > 0) {
+    const maxWave = waves[waves.length - 1];
+    const nonImplTasks = tasks.filter((t: Record<string, unknown>) => t.agent !== "adr-writer-agent");
+    const implWaves = [...new Set(nonImplTasks.map((t: Record<string, unknown>) => t.wave as number))]
+      .filter((w): w is number => typeof w === "number" && Number.isInteger(w));
+    const maxImplWave = implWaves.length > 0 ? Math.max(...implWaves) : 0;
+
+    for (const t of adrTasks) {
+      const tid = t.id as string;
+      const tw = t.wave as number;
+      if (tw !== maxWave) {
+        errors.push(`Task ${tid}: ADR task must be in the final wave (wave ${maxWave}); found wave ${tw}`);
+      }
+      if (maxImplWave > 0 && tw <= maxImplWave) {
+        errors.push(`Task ${tid}: ADR task wave (${tw}) must be greater than max impl wave (${maxImplWave})`);
+      }
+    }
+  }
+
+  return errors.length === 0 ? ok() : fail(errors);
 }
 
 /** Fix full graph — add missing per-task defaults */
@@ -180,14 +202,14 @@ const handler: HookHandler = async (stdin, args) => {
   if (isFix) {
     const fixed = isMinimal ? fixMinimal(json) : fixFull(json);
     process.stdout.write(fixed);
-    if (!result.valid) {
+    if (!result.ok) {
       process.stderr.write(`Fixed structural defaults; ${result.errors.length} issues remain\n`);
       for (const err of result.errors) process.stderr.write(`  - ${err}\n`);
     }
     return { kind: "passthrough" };
   }
 
-  if (!result.valid) {
+  if (!result.ok) {
     return {
       kind: "error",
       message: [`Validation FAILED (${result.errors.length} errors):`, ...result.errors.map((e) => `  - ${e}`)].join("\n"),

--- a/engine/src/handlers/session-start/resume-after-clear.ts
+++ b/engine/src/handlers/session-start/resume-after-clear.ts
@@ -9,16 +9,21 @@ import { TASK_GRAPH_PATH } from "../../config";
 import type { HookHandler } from "../../types";
 import type { TaskGraph, TaskStatus } from "../../types";
 
-function statusIcon(status: TaskStatus): string {
+export function statusIcon(status: TaskStatus): string {
   switch (status) {
     case "pending":     return "-";
     case "completed":   return "done";
     case "implemented": return "impl";
     case "failed":      return "FAIL";
+    default: {
+      const _exhaustive: never = status;
+      process.stderr.write(`[loom] resume-after-clear: unknown TaskStatus '${String(_exhaustive)}'\n`);
+      return "?";
+    }
   }
 }
 
-function buildContextOutput(state: TaskGraph, loomDir: string): string {
+export function buildContextOutput(state: TaskGraph, loomDir: string): string {
   const maxWave = state.tasks.reduce((m, t) => Math.max(m, t.wave), 0);
   const currentWave = state.current_wave ?? 1;
 
@@ -58,10 +63,10 @@ function buildContextOutput(state: TaskGraph, loomDir: string): string {
 
 function resolveLoomDir(): string {
   const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
-  if (pluginRoot) return pluginRoot;
-  const derived = new URL("../../../../", import.meta.url).pathname.replace(/\/$/, "");
-  process.stderr.write(`[loom] resume-after-clear: CLAUDE_PLUGIN_ROOT unset, using derived: ${derived}\n`);
-  return derived;
+  if (!pluginRoot) {
+    throw new Error("CLAUDE_PLUGIN_ROOT not set; the shell shim is expected to enforce this");
+  }
+  return pluginRoot;
 }
 
 const handler: HookHandler = async (_stdin, _args) => {

--- a/engine/src/handlers/subagent-stop/store-reviewer-findings.ts
+++ b/engine/src/handlers/subagent-stop/store-reviewer-findings.ts
@@ -14,14 +14,51 @@ import { extractTaskId } from "../../utils/extract-task-id";
 import { readTranscriptWithRetry } from "../../utils/read-transcript-with-retry";
 
 export interface ParsedFindings {
-  critical: string[];
-  advisory: string[];
-  criticalCount: number | null;
+  readonly critical: readonly string[];
+  readonly advisory: readonly string[];
+  readonly criticalCount: number | null;
 }
+
+/** Smart constructor: filter empty strings and freeze arrays. */
+export function makeParsedFindings(input: {
+  critical?: readonly string[];
+  advisory?: readonly string[];
+  criticalCount?: number | null;
+}): ParsedFindings {
+  const filter = (xs: readonly string[] | undefined): readonly string[] =>
+    Object.freeze((xs ?? []).filter((s) => s.trim() !== ""));
+  return Object.freeze({
+    critical: filter(input.critical),
+    advisory: filter(input.advisory),
+    criticalCount: input.criticalCount ?? null,
+  });
+}
+
+export const EMPTY_FINDINGS: ParsedFindings = makeParsedFindings({});
 
 /** Pure: Check if an agent type is a recognized review agent */
 export function isReviewAgent(agentType: string): boolean {
   return REVIEW_SUB_AGENTS.has(agentType);
+}
+
+/** Pure: Build evidence_capture_failed error message, surfacing partial findings if any. */
+export function buildEvidenceFailureMessage(findings: ParsedFindings): string {
+  const partial = findings.critical.length + findings.advisory.length;
+  return partial > 0
+    ? `CRITICAL_COUNT marker not found — partial findings extracted (${findings.critical.length} critical, ${findings.advisory.length} advisory)`
+    : "CRITICAL_COUNT marker not found in agent output";
+}
+
+/** Pure: Reconcile a count > 0 but empty-criticals findings into a self-describing entry,
+ *  so a broken parse cannot pass the wave gate silently. */
+export function reconcileFindings(findings: ParsedFindings): ParsedFindings {
+  if (findings.criticalCount !== null && findings.criticalCount > 0 && findings.critical.length === 0) {
+    return makeParsedFindings({
+      ...findings,
+      critical: [`Review output parsing failed - ${findings.criticalCount} findings not captured`],
+    });
+  }
+  return findings;
 }
 
 /** Pure: Merge new findings into a task, accumulating rather than overwriting.
@@ -41,7 +78,6 @@ export function mergeFindings(task: Task, findings: ParsedFindings): Task {
 /** Extract CRITICAL/ADVISORY lines and CRITICAL_COUNT from a text block.
  *  Strips code fences and handles bold/starred markers. */
 function extractFindings(block: string): ParsedFindings {
-  // Strip code fence markers so content inside fences is parsed
   const cleaned = block.replace(/^\`\`\`\w*$/gm, "");
 
   const critical: string[] = [];
@@ -49,22 +85,15 @@ function extractFindings(block: string): ParsedFindings {
 
   for (const line of cleaned.split("\n")) {
     const critMatch = line.match(/^[\s\-*]*\*{0,2}CRITICAL(?!_COUNT):?\*{0,2}\s*(.*)/);
-    if (critMatch) {
-      const text = critMatch[1].trim();
-      if (text !== '') critical.push(text);
-    }
+    if (critMatch) critical.push(critMatch[1].trim());
     const advMatch = line.match(/^[\s\-*]*\*{0,2}ADVISORY(?!_COUNT):?\*{0,2}\s*(.*)/);
-    if (advMatch) {
-      const text = advMatch[1].trim();
-      if (text !== '') advisory.push(text);
-    }
+    if (advMatch) advisory.push(advMatch[1].trim());
   }
 
-  // Match CRITICAL_COUNT with optional bold/whitespace
   const countMatch = cleaned.match(/^\*{0,2}CRITICAL_COUNT:?\*{0,2}\s*(\d+)/m);
   const criticalCount = countMatch ? Number(countMatch[1]) : null;
 
-  return { critical, advisory, criticalCount };
+  return makeParsedFindings({ critical, advisory, criticalCount });
 }
 
 /** Parse Machine Summary block for structured findings.
@@ -90,9 +119,9 @@ export function parseMachineSummary(output: string): ParsedFindings | null {
   return extractFindings(block);
 }
 
-/** Legacy fallback: scan entire output for CRITICAL/ADVISORY lines */
+/** Legacy fallback: section-headed Critical/Advisory blocks first;
+ *  fall back to whole-output line scan if no sections matched. */
 export function parseLegacyFindings(output: string): ParsedFindings {
-  // First try section-based parsing
   const critical: string[] = [];
   const advisory: string[] = [];
 
@@ -110,7 +139,6 @@ export function parseLegacyFindings(output: string): ParsedFindings {
     }
   }
 
-  // If section-based found nothing, scan full output for CRITICAL/ADVISORY lines
   if (critical.length === 0 && advisory.length === 0) {
     return extractFindings(output);
   }
@@ -118,11 +146,19 @@ export function parseLegacyFindings(output: string): ParsedFindings {
   const countMatch = output.match(/\*{0,2}CRITICAL_COUNT:?\*{0,2}\s*(\d+)/);
   const criticalCount = countMatch ? Number(countMatch[1]) : null;
 
-  return { critical, advisory, criticalCount };
+  return makeParsedFindings({ critical, advisory, criticalCount });
 }
 
 const handler: HookHandler = async (stdin) => {
-  const input: SubagentStopInput = JSON.parse(stdin);
+  let input: SubagentStopInput;
+  try {
+    input = JSON.parse(stdin);
+  } catch (e) {
+    return {
+      kind: "error",
+      message: `[loom] store-reviewer-findings: invalid JSON on stdin: ${(e as Error).message}`,
+    };
+  }
 
   const agentType = (input.agent_type ?? "").replace(/^[^:]+:/, "");
   if (!isReviewAgent(agentType)) {
@@ -137,6 +173,7 @@ const handler: HookHandler = async (stdin) => {
   const rawPath = input.agent_transcript_path ?? "";
   const transcript = await readTranscriptWithRetry(rawPath, /\*{0,2}CRITICAL_COUNT:?\*{0,2}\s*\d+/);
   if (!transcript) {
+    process.stderr.write(`[loom] store-reviewer-findings: empty transcript for ${agentType} (path=${rawPath || "<unset>"})\n`);
     return { kind: "passthrough" };
   }
 
@@ -145,36 +182,31 @@ const handler: HookHandler = async (stdin) => {
     return { kind: "passthrough" };
   }
 
-  // Try structured, then legacy
   const findings = parseMachineSummary(transcript) ?? parseLegacyFindings(transcript);
 
-  // Safety: no CRITICAL_COUNT → evidence_capture_failed
   if (findings.criticalCount === null) {
-    process.stderr.write(`WARNING: No CRITICAL_COUNT for ${taskId} — marking evidence_capture_failed\n`);
+    const errorMsg = buildEvidenceFailureMessage(findings);
+    process.stderr.write(`WARNING: ${errorMsg} for ${taskId} — marking evidence_capture_failed\n`);
     await mgr.update((s) => ({
       ...s,
       tasks: s.tasks.map((t) =>
         t.id === taskId
-          ? { ...t, review_status: "evidence_capture_failed" as ReviewStatus,
-              review_error: "CRITICAL_COUNT marker not found in agent output" }
+          ? { ...t, review_status: "evidence_capture_failed" as ReviewStatus, review_error: errorMsg }
           : t
       ),
     }));
     return { kind: "passthrough" };
   }
 
-  // Safety: criticalCount > 0 but no findings parsed → synthesize error
-  if (findings.criticalCount > 0 && findings.critical.length === 0) {
-    findings.critical.push(`Review output parsing failed - ${findings.criticalCount} findings not captured`);
-  }
+  const reconciled = reconcileFindings(findings);
 
   await mgr.update((s) => ({
     ...s,
-    tasks: s.tasks.map((t) => t.id === taskId ? mergeFindings(t, findings) : t),
+    tasks: s.tasks.map((t) => t.id === taskId ? mergeFindings(t, reconciled) : t),
   }));
 
-  const status: ReviewStatus = findings.criticalCount > 0 ? "blocked" : "passed";
-  process.stderr.write(`Task ${taskId} review: ${status} (${findings.criticalCount} critical)\n`);
+  const status: ReviewStatus = reconciled.criticalCount! > 0 ? "blocked" : "passed";
+  process.stderr.write(`Task ${taskId} review: ${status} (${reconciled.criticalCount} critical)\n`);
   return { kind: "passthrough" };
 };
 

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -10,6 +10,18 @@ export type HookResult =
   | { kind: "error"; message: string }
   | { kind: "passthrough" };
 
+/** Defense-in-depth: collapse empty diagnostic messages to a sentinel so
+ *  a silent error/block can never reach the user. Used at the cli exit boundary. */
+export function nonEmptyMessage(s: string | undefined | null): string {
+  return s && s.trim() !== "" ? s : "<no message provided>";
+}
+
+/** Smart constructors — preferred over object literals so callers funnel through nonEmptyMessage. */
+export const allowResult = (): HookResult => ({ kind: "allow" });
+export const passthroughResult = (): HookResult => ({ kind: "passthrough" });
+export const errorResult = (message: string): HookResult => ({ kind: "error", message: nonEmptyMessage(message) });
+export const blockResult = (message: string): HookResult => ({ kind: "block", message: nonEmptyMessage(message) });
+
 // --- Handler signature ---
 
 export type HookHandler = (stdin: string, args: string[]) => Promise<HookResult>;

--- a/engine/src/utils/read-transcript-with-retry.ts
+++ b/engine/src/utils/read-transcript-with-retry.ts
@@ -26,7 +26,10 @@ export async function readTranscriptWithRetry(
   markerPattern?: RegExp,
 ): Promise<string> {
   const path = rawPath.replace(/^~/, process.env.HOME ?? "~");
-  if (!path || !existsSync(path)) return "";
+  if (!path || !existsSync(path)) {
+    process.stderr.write(`[loom] read-transcript: path missing or not found: ${rawPath || "<unset>"}\n`);
+    return "";
+  }
 
   let lastSize = -1;
   let transcript = "";
@@ -53,6 +56,8 @@ export async function readTranscriptWithRetry(
     }
   }
 
-  // Return whatever we have after retries
+  if (markerPattern) {
+    process.stderr.write(`[loom] read-transcript: marker not found after ${MAX_RETRIES} retries: ${path}\n`);
+  }
   return transcript;
 }

--- a/engine/tests/handlers/complete-wave-gate.test.ts
+++ b/engine/tests/handlers/complete-wave-gate.test.ts
@@ -7,6 +7,7 @@ import {
   checkCriticalFindings,
   computeNextWave,
   generateWaveGateSummary,
+  gateCheckMessage,
 } from "../../src/handlers/helpers/complete-wave-gate";
 import type { Task, TaskGraph } from "../../src/types";
 
@@ -35,8 +36,21 @@ describe("checkTestEvidence (pure)", () => {
   it("fails when task missing test evidence", () => {
     const result = checkTestEvidence([{ ...baseTask, tests_passed: false }]);
     expect(result.passed).toBe(false);
-    expect(result.message).toContain("FAILED");
-    expect(result.message).toContain("T1");
+    expect(gateCheckMessage(result)).toContain("FAILED");
+    expect(gateCheckMessage(result)).toContain("T1");
+  });
+
+  it("passes when task has new_tests_required=false (e.g. ADR writer)", () => {
+    const adrTask: Task = {
+      ...baseTask,
+      id: "T-ADR-1",
+      new_tests_required: false,
+      tests_passed: false,
+      test_evidence: undefined,
+    };
+    const result = checkTestEvidence([adrTask]);
+    expect(result.passed).toBe(true);
+    expect(gateCheckMessage(result)).toContain("not required");
   });
 });
 
@@ -73,13 +87,13 @@ describe("checkReviews (pure)", () => {
   it("fails for pending review", () => {
     const result = checkReviews([{ ...baseTask, review_status: "pending" }]);
     expect(result.passed).toBe(false);
-    expect(result.message).toContain("Unreviewed");
+    expect(gateCheckMessage(result)).toContain("Unreviewed");
   });
 
   it("reports evidence_capture_failed separately", () => {
     const result = checkReviews([{ ...baseTask, review_status: "evidence_capture_failed" }]);
     expect(result.passed).toBe(false);
-    expect(result.message).toContain("Evidence capture failed");
+    expect(gateCheckMessage(result)).toContain("Evidence capture failed");
   });
 });
 
@@ -93,7 +107,7 @@ describe("checkCriticalFindings (pure)", () => {
     const task = { ...baseTask, critical_findings: ["SQL injection", "XSS"] };
     const result = checkCriticalFindings([task]);
     expect(result.passed).toBe(false);
-    expect(result.message).toContain("2 critical");
+    expect(gateCheckMessage(result)).toContain("2 critical");
   });
 
   it("handles undefined critical_findings", () => {
@@ -106,9 +120,9 @@ describe("checkCriticalFindings (pure)", () => {
     const task = { ...baseTask, critical_findings: ["", "  ", "Real finding"] };
     const result = checkCriticalFindings([task]);
     expect(result.passed).toBe(false);
-    expect(result.message).toContain("1 critical");
-    expect(result.message).toContain("Real finding");
-    expect(result.message).not.toContain('""');
+    expect(gateCheckMessage(result)).toContain("1 critical");
+    expect(gateCheckMessage(result)).toContain("Real finding");
+    expect(gateCheckMessage(result)).not.toContain('""');
   });
 
   it("passes when critical_findings only contains empty strings", () => {
@@ -133,7 +147,7 @@ describe("checkSpecAlignment (pure)", () => {
   it("passes when no spec-check data", () => {
     const result = checkSpecAlignment(mkState(), 1);
     expect(result.passed).toBe(true);
-    expect(result.message).toContain("skipped");
+    expect(gateCheckMessage(result)).toContain("skipped");
   });
 
   it("fails when spec-check for different wave", () => {
@@ -142,8 +156,8 @@ describe("checkSpecAlignment (pure)", () => {
     });
     const result = checkSpecAlignment(state, 2);
     expect(result.passed).toBe(false);
-    expect(result.message).toContain("wave 1");
-    expect(result.message).toContain("not 2");
+    expect(gateCheckMessage(result)).toContain("wave 1");
+    expect(gateCheckMessage(result)).toContain("not 2");
   });
 
   it("passes when spec-check matches wave with no criticals", () => {
@@ -160,7 +174,7 @@ describe("checkSpecAlignment (pure)", () => {
     });
     const result = checkSpecAlignment(state, 1);
     expect(result.passed).toBe(false);
-    expect(result.message).toContain("2 critical");
+    expect(gateCheckMessage(result)).toContain("2 critical");
   });
 });
 

--- a/engine/tests/handlers/session-start/resume-after-clear.test.ts
+++ b/engine/tests/handlers/session-start/resume-after-clear.test.ts
@@ -3,7 +3,8 @@ import { mkdirSync, writeFileSync, chmodSync, rmSync, existsSync } from "node:fs
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
-import type { TaskGraph, Task } from "../../../src/types";
+import type { TaskGraph, Task, TaskStatus } from "../../../src/types";
+import { buildContextOutput, statusIcon } from "../../../src/handlers/session-start/resume-after-clear";
 
 const CLI_PATH = join(__dirname, "../../../src/cli.ts");
 
@@ -61,11 +62,12 @@ describe("resume-after-clear handler", () => {
     chmodSync(statePath, 0o444);
   }
 
-  function runHandler(): { exitCode: number; stdout: string; stderr: string } {
+  function runHandler(envOverrides: NodeJS.ProcessEnv = {}): { exitCode: number; stdout: string; stderr: string } {
+    const env = { ...process.env, CLAUDE_PLUGIN_ROOT: "/test/loom-plugin", ...envOverrides };
     try {
       const stdout = execSync(
         `bun "${CLI_PATH}" session-start resume-after-clear`,
-        { cwd: tmpDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+        { cwd: tmpDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], env },
       );
       return { exitCode: 0, stdout: stdout ?? "", stderr: "" };
     } catch (e: unknown) {
@@ -224,5 +226,83 @@ describe("resume-after-clear handler", () => {
     writeState(makeGraph({ github_issue: undefined }));
     const { stdout } = runHandler();
     expect(stdout).not.toContain("**GitHub Issue:**");
+  });
+});
+
+describe("statusIcon (pure)", () => {
+  it("maps each known status", () => {
+    expect(statusIcon("pending")).toBe("-");
+    expect(statusIcon("completed")).toBe("done");
+    expect(statusIcon("implemented")).toBe("impl");
+    expect(statusIcon("failed")).toBe("FAIL");
+  });
+
+  it("returns ? sentinel for unknown status (defensive)", () => {
+    // Cast bypasses exhaustiveness — simulates a future status that hasn't been wired yet.
+    expect(statusIcon("ghost" as TaskStatus)).toBe("?");
+  });
+});
+
+describe("buildContextOutput (pure)", () => {
+  function task(overrides: Partial<Task> = {}): Task {
+    return {
+      id: "T1", description: "Build thing", agent: "code-implementer-agent",
+      wave: 1, status: "pending", depends_on: [], ...overrides,
+    };
+  }
+  function graph(overrides: Partial<TaskGraph> = {}): TaskGraph {
+    return {
+      current_phase: "execute", phase_artifacts: {}, skipped_phases: [],
+      spec_file: ".claude/specs/x/spec.md", plan_file: ".claude/plans/x.md",
+      tasks: [task()], wave_gates: {}, ...overrides,
+    };
+  }
+
+  it("emits context markers and tasks table", () => {
+    const out = buildContextOutput(graph(), "/loom");
+    expect(out).toContain("<!-- LOOM RESUME CONTEXT -->");
+    expect(out).toContain("<!-- END LOOM RESUME CONTEXT -->");
+    expect(out).toContain("# Active Loom Session — Execute Phase");
+    expect(out).toContain("| ID | Wave | Agent | Status | Description |");
+    expect(out).toContain("| T1 | 1 | code-implementer-agent | - | Build thing |");
+  });
+
+  it("sorts tasks by wave then id", () => {
+    const out = buildContextOutput(graph({
+      tasks: [
+        task({ id: "T2", wave: 2 }),
+        task({ id: "T1", wave: 1 }),
+        task({ id: "T3", wave: 1 }),
+      ],
+    }), "/loom");
+    const t1 = out.indexOf("| T1 |");
+    const t3 = out.indexOf("| T3 |");
+    const t2 = out.indexOf("| T2 |");
+    expect(t1).toBeLessThan(t3);
+    expect(t3).toBeLessThan(t2);
+  });
+
+  it("renders github issue line with repo when both set", () => {
+    const out = buildContextOutput(graph({ github_issue: 42, github_repo: "owner/repo" }), "/loom");
+    expect(out).toContain("**GitHub Issue:** owner/repo#42");
+  });
+
+  it("renders github issue line without repo when repo absent", () => {
+    const out = buildContextOutput(graph({ github_issue: 42 }), "/loom");
+    expect(out).toContain("**GitHub Issue:** #42");
+  });
+
+  it("interpolates loomDir into instructions", () => {
+    const out = buildContextOutput(graph(), "/abs/loom");
+    expect(out).toContain("/abs/loom/commands/loom.md");
+    expect(out).toContain("/abs/loom/commands/templates/impl-agent-context.md");
+  });
+
+  it("computes maxWave from highest task wave", () => {
+    const out = buildContextOutput(graph({
+      tasks: [task({ id: "T1", wave: 1 }), task({ id: "T2", wave: 3 })],
+      current_wave: 2,
+    }), "/loom");
+    expect(out).toContain("**Current Wave:** 2 of 3");
   });
 });

--- a/engine/tests/handlers/store-reviewer-findings.test.ts
+++ b/engine/tests/handlers/store-reviewer-findings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseMachineSummary, parseLegacyFindings, isReviewAgent, mergeFindings } from "../../src/handlers/subagent-stop/store-reviewer-findings";
+import { parseMachineSummary, parseLegacyFindings, isReviewAgent, mergeFindings, buildEvidenceFailureMessage, reconcileFindings } from "../../src/handlers/subagent-stop/store-reviewer-findings";
 import { REVIEW_SUB_AGENTS } from "../../src/config";
 import type { Task } from "../../src/types";
 
@@ -405,5 +405,46 @@ describe("mergeFindings (pure)", () => {
     expect(task.critical_findings).toEqual(["C1", "C2"]);
     expect(task.advisory_findings).toEqual(["A1", "A2", "A3"]);
     expect(task.review_status).toBe("blocked");
+  });
+});
+
+describe("buildEvidenceFailureMessage (pure)", () => {
+  it("returns generic message when no partial findings", () => {
+    const msg = buildEvidenceFailureMessage({ critical: [], advisory: [], criticalCount: null });
+    expect(msg).toBe("CRITICAL_COUNT marker not found in agent output");
+  });
+
+  it("surfaces partial counts when section parsing extracted findings", () => {
+    const msg = buildEvidenceFailureMessage({
+      critical: ["XSS in template", "SQL injection"],
+      advisory: ["Refactor advised"],
+      criticalCount: null,
+    });
+    expect(msg).toContain("partial findings extracted");
+    expect(msg).toContain("2 critical");
+    expect(msg).toContain("1 advisory");
+  });
+});
+
+describe("reconcileFindings (pure)", () => {
+  it("synthesizes placeholder when count > 0 but no critical findings parsed", () => {
+    const result = reconcileFindings({ critical: [], advisory: [], criticalCount: 3 });
+    expect(result.critical).toHaveLength(1);
+    expect(result.critical[0]).toContain("3 findings not captured");
+  });
+
+  it("returns input unchanged when count and findings agree", () => {
+    const input = { critical: ["x"], advisory: [], criticalCount: 1 };
+    expect(reconcileFindings(input)).toBe(input);
+  });
+
+  it("returns input unchanged when count is 0", () => {
+    const input = { critical: [], advisory: ["a"], criticalCount: 0 };
+    expect(reconcileFindings(input)).toBe(input);
+  });
+
+  it("returns input unchanged when count is null", () => {
+    const input = { critical: [], advisory: [], criticalCount: null };
+    expect(reconcileFindings(input)).toBe(input);
   });
 });

--- a/engine/tests/handlers/validate-task-graph.property.test.ts
+++ b/engine/tests/handlers/validate-task-graph.property.test.ts
@@ -12,7 +12,9 @@ function wrapTasks(tasks: Record<string, unknown>[]) {
   };
 }
 
-/** Known agents from config (subset for generation) */
+/** Known agents from config (subset for generation).
+ *  adr-writer-agent is excluded because it has wave-placement constraints
+ *  that conflict with the random-graph generator (covered by unit tests instead). */
 const AGENTS = [
   "code-implementer-agent",
   "ts-test-agent",
@@ -75,8 +77,11 @@ describe("validateFull — property tests", () => {
     fc.assert(
       fc.property(arbValidGraph(), (graph) => {
         const result = validateFull(graph);
-        expect(result.valid).toBe(true);
-        expect(result.errors).toHaveLength(0);
+        expect(result.ok).toBe(true);
+        if (!result.ok) {
+          // Unreachable when result.ok — kept for diagnostic if assertion above fails
+          expect(result.errors).toEqual([]);
+        }
       }),
       { numRuns: 200 },
     );
@@ -92,7 +97,7 @@ describe("validateFull — property tests", () => {
             { id: `T${n}`, description: "self dep", agent, wave: 1, depends_on: [`T${n}`] },
           ]);
           const result = validateFull(graph);
-          expect(result.valid).toBe(false);
+          expect(result.ok).toBe(false);
           expect(result.errors.some((e) => e.includes("self-dependency"))).toBe(true);
         },
       ),
@@ -110,7 +115,7 @@ describe("validateFull — property tests", () => {
             { id: "T2", description: "second", agent, wave, depends_on: ["T1"] },
           ]);
           const result = validateFull(graph);
-          expect(result.valid).toBe(false);
+          expect(result.ok).toBe(false);
           expect(result.errors.some((e) => e.includes("earlier wave"))).toBe(true);
         },
       ),
@@ -128,7 +133,7 @@ describe("validateFull — property tests", () => {
             { id: "T2", description: "wave2", agent, wave: baseWave + 1, depends_on: [] },
           ]);
           const result = validateFull(graph);
-          expect(result.valid).toBe(false);
+          expect(result.ok).toBe(false);
         },
       ),
     );
@@ -138,7 +143,7 @@ describe("validateFull — property tests", () => {
 describe("validateFull — edge cases", () => {
   it("rejects 0 tasks (empty array)", () => {
     const result = validateFull(wrapTasks([]));
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors.some((e) => e.includes("empty"))).toBe(true);
   });
 
@@ -146,7 +151,7 @@ describe("validateFull — edge cases", () => {
     const result = validateFull(
       wrapTasks([{ id: "T1", description: "solo", agent: "frontend-agent", wave: 1, depends_on: [] }]),
     );
-    expect(result.valid).toBe(true);
+    expect(result.ok).toBe(true);
   });
 
   it("accepts all tasks same wave, no deps", () => {
@@ -157,7 +162,7 @@ describe("validateFull — edge cases", () => {
         { id: "T3", description: "c", agent: "security-agent", wave: 1, depends_on: [] },
       ]),
     );
-    expect(result.valid).toBe(true);
+    expect(result.ok).toBe(true);
   });
 
   it("rejects dependency on non-existent ID", () => {
@@ -166,7 +171,7 @@ describe("validateFull — edge cases", () => {
         { id: "T1", description: "a", agent: "frontend-agent", wave: 1, depends_on: ["T99"] },
       ]),
     );
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors.some((e) => e.includes("non-existent"))).toBe(true);
   });
 
@@ -178,7 +183,7 @@ describe("validateFull — edge cases", () => {
         { id: "T3", description: "c", agent: "security-agent", wave: 2, depends_on: ["T1", "T2"] },
       ]),
     );
-    expect(result.valid).toBe(true);
+    expect(result.ok).toBe(true);
   });
 
   it("rejects duplicate task IDs by failing validation on second", () => {
@@ -200,7 +205,7 @@ describe("validateFull — edge cases", () => {
         { id: "T2", description: "b", agent: "ts-test-agent", wave: 3, depends_on: ["T1"] },
       ]),
     );
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors.some(e => e.includes("Wave gap"))).toBe(true);
   });
 
@@ -210,7 +215,7 @@ describe("validateFull — edge cases", () => {
         { id: "T1", description: "a", agent: "frontend-agent", wave: 999, depends_on: [] },
       ]),
     );
-    expect(result.valid).toBe(true);
+    expect(result.ok).toBe(true);
   });
 
   it("rejects unknown agent names", () => {
@@ -219,7 +224,7 @@ describe("validateFull — edge cases", () => {
         { id: "T1", description: "a", agent: "nonexistent-agent", wave: 1, depends_on: [] },
       ]),
     );
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors.some((e) => e.includes("unknown agent"))).toBe(true);
   });
 
@@ -229,7 +234,7 @@ describe("validateFull — edge cases", () => {
         { id: "T1", description: "a", agent: "frontend-agent", wave: 0, depends_on: [] },
       ]),
     );
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors.some((e) => e.includes("wave must be integer >= 1"))).toBe(true);
   });
 
@@ -239,14 +244,14 @@ describe("validateFull — edge cases", () => {
         { id: "T1", description: "a", agent: "frontend-agent", wave: 1.5, depends_on: [] },
       ]),
     );
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
   });
 
   it("rejects missing task ID", () => {
     const result = validateFull(
       wrapTasks([{ description: "no id", agent: "frontend-agent", wave: 1, depends_on: [] }]),
     );
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors.some((e) => e.includes("missing 'id'"))).toBe(true);
   });
 
@@ -254,7 +259,7 @@ describe("validateFull — edge cases", () => {
     const result = validateFull(
       wrapTasks([{ id: "TASK1", description: "bad id", agent: "frontend-agent", wave: 1, depends_on: [] }]),
     );
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors.some((e) => e.includes("must match"))).toBe(true);
   });
 });

--- a/engine/tests/handlers/validate-task-graph.test.ts
+++ b/engine/tests/handlers/validate-task-graph.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { validateMinimal, validateFull } from "../../src/handlers/helpers/validate-task-graph";
 
 describe("validateMinimal (pure)", () => {
@@ -10,37 +10,36 @@ describe("validateMinimal (pure)", () => {
       spec_file: null,
       plan_file: null,
     });
-    expect(result.valid).toBe(true);
-    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
   });
 
   it("rejects missing current_phase", () => {
     const result = validateMinimal({ phase_artifacts: {}, skipped_phases: [], spec_file: null, plan_file: null });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors).toContain("Missing required field: current_phase");
   });
 
   it("rejects invalid phase value", () => {
     const result = validateMinimal({ current_phase: "invalid", phase_artifacts: {}, skipped_phases: [], spec_file: null, plan_file: null });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain("not a valid phase");
   });
 
   it("rejects non-object phase_artifacts", () => {
     const result = validateMinimal({ current_phase: "init", phase_artifacts: "string", skipped_phases: [], spec_file: null, plan_file: null });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain("phase_artifacts must be object");
   });
 
   it("rejects non-array skipped_phases", () => {
     const result = validateMinimal({ current_phase: "init", phase_artifacts: {}, skipped_phases: "string", spec_file: null, plan_file: null });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain("skipped_phases must be array");
   });
 
   it("rejects missing spec_file and plan_file keys", () => {
     const result = validateMinimal({ current_phase: "init", phase_artifacts: {}, skipped_phases: [] });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors).toContain("Missing required field: spec_file");
     expect(result.errors).toContain("Missing required field: plan_file");
   });
@@ -62,24 +61,24 @@ describe("validateFull (pure)", () => {
       spec_file: ".claude/specs/spec.md",
       tasks: [validTask],
     });
-    expect(result.valid).toBe(true);
+    expect(result.ok).toBe(true);
   });
 
   it("rejects missing required top-level fields", () => {
     const result = validateFull({ tasks: [validTask] });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors).toContain("Missing required field: plan_title");
   });
 
   it("rejects non-array tasks", () => {
     const result = validateFull({ plan_title: "x", plan_file: "x", spec_file: "x", tasks: "not-array" });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors).toContain("'tasks' must be an array");
   });
 
   it("rejects empty tasks array", () => {
     const result = validateFull({ plan_title: "x", plan_file: "x", spec_file: "x", tasks: [] });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors).toContain("'tasks' array is empty");
   });
 
@@ -88,7 +87,7 @@ describe("validateFull (pure)", () => {
       plan_title: "x", plan_file: "x", spec_file: "x",
       tasks: [{ ...validTask, id: "bad-id" }],
     });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain("id must match");
   });
 
@@ -97,7 +96,7 @@ describe("validateFull (pure)", () => {
       plan_title: "x", plan_file: "x", spec_file: "x",
       tasks: [{ ...validTask, agent: "fake-agent" }],
     });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain("unknown agent");
   });
 
@@ -106,7 +105,7 @@ describe("validateFull (pure)", () => {
       plan_title: "x", plan_file: "x", spec_file: "x",
       tasks: [{ ...validTask, depends_on: ["T1"] }],
     });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain("self-dependency");
   });
 
@@ -115,7 +114,7 @@ describe("validateFull (pure)", () => {
       plan_title: "x", plan_file: "x", spec_file: "x",
       tasks: [{ ...validTask, depends_on: ["T99"] }],
     });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain("non-existent");
   });
 
@@ -127,7 +126,7 @@ describe("validateFull (pure)", () => {
         { ...validTask, id: "T2", wave: 1, depends_on: ["T1"] },
       ],
     });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain("deps must be in earlier wave");
   });
 
@@ -139,7 +138,7 @@ describe("validateFull (pure)", () => {
         { ...validTask, id: "T2", wave: 2, depends_on: ["T1"] },
       ],
     });
-    expect(result.valid).toBe(true);
+    expect(result.ok).toBe(true);
   });
 
   it("rejects wave gaps (1 → 3)", () => {
@@ -150,7 +149,7 @@ describe("validateFull (pure)", () => {
         { ...validTask, id: "T2", wave: 3, depends_on: [] },
       ],
     });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     expect(result.errors[0]).toContain("Wave gap");
   });
 
@@ -163,9 +162,74 @@ describe("validateFull (pure)", () => {
         { ...validTask, id: "T3", wave: 7, depends_on: [] },
       ],
     });
-    expect(result.valid).toBe(false);
+    expect(result.ok).toBe(false);
     const gapErrors = result.errors.filter(e => e.includes("Wave gap"));
     expect(gapErrors).toHaveLength(2);
+  });
+
+  it("does not warn when new_tests_required=false and description mentions ADR", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const result = validateFull({
+      plan_title: "x", plan_file: "x", spec_file: "x",
+      tasks: [
+        { ...validTask, id: "T1", description: "Write ADR for state-management decision",
+          new_tests_required: false, agent: "adr-writer-agent" },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    const warned = stderr.mock.calls.some(([msg]) => String(msg).includes("doesn't match no-test patterns"));
+    expect(warned).toBe(false);
+    stderr.mockRestore();
+  });
+
+  it("warns when new_tests_required=false and description has no exempt keyword", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    validateFull({
+      plan_title: "x", plan_file: "x", spec_file: "x",
+      tasks: [{ ...validTask, description: "Implement core auth logic", new_tests_required: false }],
+    });
+    const warned = stderr.mock.calls.some(([msg]) => String(msg).includes("doesn't match no-test patterns"));
+    expect(warned).toBe(true);
+    stderr.mockRestore();
+  });
+
+  it("accepts ADR task in final wave with impl tasks in earlier waves", () => {
+    const result = validateFull({
+      plan_title: "x", plan_file: "x", spec_file: "x",
+      tasks: [
+        { ...validTask, id: "T1", wave: 1, agent: "code-implementer-agent" },
+        { ...validTask, id: "T2", wave: 2, depends_on: ["T1"],
+          agent: "adr-writer-agent", description: "Write ADR for choice", new_tests_required: false },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects ADR task in same wave as impl tasks", () => {
+    const result = validateFull({
+      plan_title: "x", plan_file: "x", spec_file: "x",
+      tasks: [
+        { ...validTask, id: "T1", wave: 1, agent: "code-implementer-agent" },
+        { ...validTask, id: "T2", wave: 1,
+          agent: "adr-writer-agent", description: "Write ADR for choice", new_tests_required: false },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.includes("ADR task wave"))).toBe(true);
+  });
+
+  it("rejects ADR task in non-final wave", () => {
+    const result = validateFull({
+      plan_title: "x", plan_file: "x", spec_file: "x",
+      tasks: [
+        { ...validTask, id: "T1", wave: 1, agent: "code-implementer-agent" },
+        { ...validTask, id: "T2", wave: 2, depends_on: ["T1"],
+          agent: "adr-writer-agent", description: "ADR doc", new_tests_required: false },
+        { ...validTask, id: "T3", wave: 3, depends_on: ["T1"], agent: "code-implementer-agent" },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.includes("must be in the final wave"))).toBe(true);
   });
 
   it("accepts contiguous waves (1, 2, 3)", () => {
@@ -177,6 +241,6 @@ describe("validateFull (pure)", () => {
         { ...validTask, id: "T3", wave: 3, depends_on: [] },
       ],
     });
-    expect(result.valid).toBe(true);
+    expect(result.ok).toBe(true);
   });
 });

--- a/engine/tests/types.test.ts
+++ b/engine/tests/types.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { nonEmptyMessage, errorResult, blockResult, allowResult, passthroughResult } from "../src/types";
+
+describe("nonEmptyMessage (boundary defense)", () => {
+  it("preserves non-empty input", () => {
+    expect(nonEmptyMessage("validation failed")).toBe("validation failed");
+  });
+
+  it("rewrites empty string to sentinel", () => {
+    expect(nonEmptyMessage("")).toBe("<no message provided>");
+  });
+
+  it("rewrites whitespace-only string to sentinel", () => {
+    expect(nonEmptyMessage("   \n\t")).toBe("<no message provided>");
+  });
+
+  it("rewrites null/undefined to sentinel", () => {
+    expect(nonEmptyMessage(null)).toBe("<no message provided>");
+    expect(nonEmptyMessage(undefined)).toBe("<no message provided>");
+  });
+});
+
+describe("HookResult smart constructors", () => {
+  it("errorResult sanitizes empty messages", () => {
+    const r = errorResult("");
+    expect(r).toEqual({ kind: "error", message: "<no message provided>" });
+  });
+
+  it("blockResult sanitizes empty messages", () => {
+    const r = blockResult("   ");
+    expect(r).toEqual({ kind: "block", message: "<no message provided>" });
+  });
+
+  it("errorResult preserves real messages", () => {
+    const r = errorResult("oops");
+    expect(r).toEqual({ kind: "error", message: "oops" });
+  });
+
+  it("allowResult and passthroughResult have no payload", () => {
+    expect(allowResult()).toEqual({ kind: "allow" });
+    expect(passthroughResult()).toEqual({ kind: "passthrough" });
+  });
+});

--- a/hooks/scripts/resume-after-clear.sh
+++ b/hooks/scripts/resume-after-clear.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
-# Inject loom execution context after /clear — stdout goes into fresh conversation
+# Stdout from this hook injects context into the conversation post-/clear.
+set -euo pipefail
 GRAPH="${CLAUDE_PROJECT_DIR:-.}/.claude/state/active_task_graph.json"
 if [ ! -f "$GRAPH" ]; then
   cat > /dev/null
   exit 0
 fi
 
-if [ -z "${CLAUDE_PLUGIN_ROOT}" ]; then
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
   echo "[loom] resume-after-clear: CLAUDE_PLUGIN_ROOT not set" >&2
+  exit 1
+fi
+
+if ! command -v bun > /dev/null 2>&1; then
+  echo "[loom] resume-after-clear: bun not found on PATH" >&2
   exit 1
 fi
 

--- a/references/adr-template.md
+++ b/references/adr-template.md
@@ -1,0 +1,40 @@
+# ADR Template
+
+Use this template when emitting an ADR from `phase-architecture.md` Step 6. Substitute all `{...}` placeholders. Output filename: `docs/adr/{NNNN}-{title-slug}.md`.
+
+---
+
+# ADR-{NNNN}: {Title}
+
+## Status
+{Accepted | Proposed | Superseded by ADR-NNNN | Deprecated}
+
+## Context
+{Why this decision is needed. Forces at play: technical, organizational, regulatory. 1–3 short paragraphs. State the problem, not the solution.}
+
+## Options Considered
+
+1. **{Option name}**
+   - Pros: {list}
+   - Cons: {list}
+
+2. **{Option name}**
+   - Pros: {list}
+   - Cons: {list}
+
+{Add more as needed. If no real alternatives existed (forced choice), state that explicitly: "Only viable option given X constraint" — but still record the decision.}
+
+## Decision
+**{One-line statement of the chosen option.}**
+
+{Followed by detail: architecture, components, key invariants, file paths, naming conventions. Concrete enough that a future reader can map decision → code.}
+
+## Consequences
+
+**Positive:**
+- {benefit}
+- {benefit}
+
+**Negative:**
+- {cost / tradeoff / risk accepted}
+- {cost / tradeoff / risk accepted}

--- a/references/adr-template.md
+++ b/references/adr-template.md
@@ -1,6 +1,6 @@
 # ADR Template
 
-Use this template when emitting an ADR from `phase-architecture.md` Step 6. Substitute all `{...}` placeholders. Output filename: `docs/adr/{NNNN}-{title-slug}.md`.
+Used by `adr-writer-agent` when expanding plan AD-N seeds into full ADRs (one task per AD, scheduled by `phase-decompose.md` rule 6). Substitute all `{...}` placeholders. Output filename: `docs/adr/{NNNN}-{title-slug}.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds ADR emission to loom by extending the **decompose phase**, not the architecture phase. The architecture-agent seeds decisions as `### AD-N` blocks in `## Architectural Decisions` (plan-template already supports this); decompose-agent expands each AD into a dedicated task in the final wave; a new `adr-writer-agent` produces one ADR per task with fresh context.

This matches the pattern that produced the chatbot repo's high-quality `docs/adr/0001-0015` batch — one agent, one ADR, focused prompt.

## Why not the architecture phase?

Initial commit on this branch (1569857) put ADR emission in `phase-architecture.md` Step 6. That asks one agent — already deep in spec/codebase/options/plan — to also write N ADRs at the end. Predictable failure: shallow Context, templated Options, weak Consequences. The pivot to decompose tasks (37b03e3) preserves the engineering-maturity Wave 5 pattern that produced the existing high-quality batch.

## Changes

- **`agents/adr-writer-agent.md`** (new) — ~10-line stub. Loads `references/adr-template.md`, expands one AD seed per invocation. No preloaded skill — the system prompt is self-contained.
- **`references/adr-template.md`** (new) — shared shape, mirrors `plan-template.md` / `spec-template.md`. Status / Context / Options Considered / Decision / Consequences. No front-matter, no date field (git is source of truth).
- **`engine/src/config.ts`** — add `adr-writer-agent` to `IMPL_AGENTS`. Cascades through `validate-agent-model`, `validate-phase-order`, `validate-agent-skill`, `validate-task-graph`, `dispatch` — all import from this Set.
- **`commands/templates/phase-decompose.md`** — agents table entry + new Decompose Rule 6: for each `### AD-N` block in plan, emit one task with `adr-writer-agent` in the final wave. Decompose pre-allocates ADR numbers by reading `docs/adr/`.
- **`commands/templates/phase-architecture.md`** — short note in Step 5 telling architecture-agent to capture decisions as `AD-N` blocks. Does NOT write ADRs in this phase.

## Flow

```
architecture-agent writes plan.md with ## Architectural Decisions: AD-1, AD-2, ...
   │
   ▼
decompose-agent expands each AD into one task in the final wave
   │ (pre-allocates docs/adr/NNNN-slug.md by scanning existing ADRs)
   ▼
adr-writer-agent runs once per ADR — fresh context, focused prompt
   │
   ▼
docs/adr/NNNN-slug.md (one file per invocation)
```

## Wiring verification

- 438 engine tests pass after `IMPL_AGENTS` change — no regressions.
- ADR tasks treated identically to other impl tasks: SubagentStop dispatch routes to "impl" handler → mark task implemented → wave-gate runs.

## Edge cases

| Case | Handling |
|------|----------|
| Plan has no `## Architectural Decisions` section | No ADR tasks created |
| Single AD | One ADR task in final wave |
| Plan-alignment loop-back changes ADs | Architecture re-runs → new plan → decompose re-runs → fresh task graph |
| Title slug collision | Decompose appends `-2`, `-3` — NNNN prefix prevents file collision |
| Final-wave ADR task fails wave-gate | Standard retry/fix loop, treated like any impl task |

## Test plan

- [ ] Run `/loom "small feature with 1-2 design decisions"` against a test repo. Verify decompose creates ADR tasks, ADRs emitted to `docs/adr/` with sequential numbering.
- [ ] Verify ADRs follow `references/adr-template.md` structure end-to-end.
- [ ] Run `/loom` for trivial feature (no ADs in plan) → verify no ADR tasks created.
- [ ] Test plan-alignment loop-back → verify ADR tasks regenerated correctly with stable numbering.
- [ ] Verify final-wave ADR task failure interacts correctly with wave-gate.