### PR TITLE
feat: add pi coding agent compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .memory/
 .claude/cortex-memory.local.md
+.pi/cortex-memory.local.md

--- a/docs/migration-claude-code-to-pi.md
+++ b/docs/migration-claude-code-to-pi.md
@@ -1,0 +1,1759 @@
+# Migration Guide: Claude Code → Pi
+
+Migrating plugins, skills, commands, hooks, and settings from Claude Code to the [pi coding agent](https://pi.dev) harness.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Concept Mapping](#concept-mapping)
+- [1. Context Files](#1-context-files)
+- [2. Commands → Prompt Templates & Skills](#2-commands--prompt-templates--skills)
+- [3. Hooks → Extensions](#3-hooks--extensions)
+- [4. Plugins → Pi Packages](#4-plugins--pi-packages)
+- [5. Marketplace Skills](#5-marketplace-skills)
+- [6. Settings](#6-settings)
+- [7. Quick Start Migration Steps](#7-quick-start-migration-steps)
+- [8. Sub-Agents](#8-sub-agents)
+- [9. Session File Format (JSONL Transcript Parsing)](#9-session-file-format-jsonl-transcript-parsing)
+- [Key Differences](#key-differences)
+- [Appendix: Loom Plugin Deep Dive](#appendix-loom-plugin-deep-dive)
+
+---
+
+## Overview
+
+Claude Code organizes customization into plugins (bundles of commands, hooks, and skills), marketplace skills, context files (`CLAUDE.md`), and settings. Pi uses a different but largely compatible set of primitives:
+
+| Claude Code | Pi |
+|---|---|
+| Commands (`.md` files) | **Prompt Templates** or **Skills** |
+| Hooks (shell scripts via `hooks.json`) | **Extensions** (TypeScript event handlers) |
+| Plugins (bundles) | **Pi Packages** (npm/git) or local extensions + skills |
+| Marketplace skills (`SKILL.md`) | **Skills** (same Agent Skills standard) |
+| `CLAUDE.md` | `AGENTS.md` (pi also loads `CLAUDE.md`) |
+| `settings.json` / `settings.local.json` | `~/.pi/agent/settings.json` / `.pi/settings.json` |
+
+---
+
+## Concept Mapping
+
+### Claude Code Hook → Pi Extension Event
+
+| Claude Code Hook | Pi Extension Event | Notes |
+|---|---|---|
+| `PreToolUse` | `pi.on("tool_call", ...)` | Can block, mutate input |
+| `PostToolUse` | `pi.on("tool_result", ...)` | Can modify result |
+| `SessionStart` | `pi.on("session_start", ...)` | Fires on start/reload/resume |
+| `SessionEnd` | `pi.on("session_shutdown", ...)` | Fires on quit/reload/switch |
+| `UserPromptSubmit` | `pi.on("input", ...)` or `pi.on("before_agent_start", ...)` | Input for transform/intercept, before_agent_start for context injection |
+| `SubagentStart` | Custom tool or `pi.sendUserMessage()` | Sub-agents not built-in; build with extensions |
+| `SubagentStop` | Custom tool or event handler | Build dispatch logic in extension |
+
+### Claude Code Directory → Pi Directory
+
+| Claude Code | Pi |
+|---|---|
+| `~/.claude/` | `~/.pi/agent/` |
+| `~/.claude/CLAUDE.md` | `~/.pi/agent/AGENTS.md` |
+| `.claude/CLAUDE.md` | `.pi/AGENTS.md` (or keep `CLAUDE.md` in project root) |
+| `.claude/settings.local.json` | `.pi/settings.json` |
+| Plugin `commands/*.md` | `~/.pi/agent/prompts/` or `~/.pi/agent/skills/` |
+| Plugin `hooks/` | `~/.pi/agent/extensions/*.ts` |
+| Plugin `skills/` | `~/.pi/agent/skills/` |
+
+---
+
+## 1. Context Files
+
+Pi auto-discovers both `AGENTS.md` **and** `CLAUDE.md`, so existing context files work without changes.
+
+| Claude Code | Pi | Action |
+|---|---|---|
+| `~/.claude/CLAUDE.md` | `~/.pi/agent/AGENTS.md` | Copy or symlink |
+| Project `CLAUDE.md` | Keep as-is | Pi loads it automatically |
+| `.claude/CLAUDE.md` | `.pi/AGENTS.md` or project root `CLAUDE.md` | Move or symlink |
+
+Pi loads context files from:
+- `~/.pi/agent/AGENTS.md` (global)
+- Parent directories walking up from cwd
+- Current directory
+
+---
+
+## 2. Commands → Prompt Templates & Skills
+
+Claude Code "commands" are `.md` files that expand when you type `/commandname`. In pi, these map to two things depending on complexity:
+
+### Simple Commands → Prompt Templates
+
+For commands that are just text expansions (no scripts, no multi-file references):
+
+```bash
+# Copy the markdown file to pi's prompts directory
+cp ~/.claude/plugins/cache/plugins/feynman/0.1.0/commands/feynman.md \
+   ~/.pi/agent/prompts/feynman.md
+```
+
+Place in `~/.pi/agent/prompts/` (global) or `.pi/prompts/` (project-local). Use with `/feynman` in pi.
+
+Prompt templates support variables:
+
+```markdown
+<!-- ~/.pi/agent/prompts/review.md -->
+Review this code for bugs, security issues, and performance problems.
+Focus on: {{focus}}
+```
+
+### Complex Commands → Skills
+
+For commands with scripts, references, or multi-file structures:
+
+```bash
+# Copy the entire skill directory
+cp -r ~/dev/claude-plugins/loom/skills/nextjs-frontend-design \
+   ~/.pi/agent/skills/nextjs-frontend-design
+```
+
+Ensure the skill has a `SKILL.md` with proper frontmatter:
+
+```markdown
+---
+name: nextjs-frontend-design
+description: Frontend design patterns for Next.js applications with component library, animation recipes, and TypeScript patterns.
+---
+
+# Next.js Frontend Design
+...
+```
+
+Place in `~/.pi/agent/skills/` (global) or `.pi/skills/` (project-local). Use with `/skill:nextjs-frontend-design` in pi.
+
+### Decision Guide
+
+| Command Type | Pi Target | Example |
+|---|---|---|
+| Simple text prompt | Prompt Template (`prompts/`) | `/feynman`, `/clarify`, `/brainstorming` |
+| Has scripts/references/assets | Skill (`skills/`) | `/loom`, `/nextjs-frontend-design` |
+| Registers slash command with logic | Extension (`extensions/`) | Custom commands needing programmatic behavior |
+
+---
+
+## 3. Hooks → Extensions
+
+This is the biggest migration effort. Claude Code hooks are shell scripts triggered by JSON config. Pi uses TypeScript extensions with event handlers.
+
+### Extension Basics
+
+Create `~/.pi/agent/extensions/my-extension.ts`:
+
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("event_name", async (event, ctx) => {
+    // handle event
+  });
+}
+```
+
+Extensions are auto-discovered from `~/.pi/agent/extensions/` (global) and `.pi/extensions/` (project-local). Hot-reload with `/reload`.
+
+### Example: Cortex Memory Hooks → Extension
+
+**Claude Code (`hooks.json`):**
+```json
+{
+  "SessionStart": [{ "command": "bash .../load-surface.sh" }],
+  "SessionEnd": [{ "command": "bash .../extract-and-generate.sh" }],
+  "UserPromptSubmit": [
+    { "command": "cat .claude/cortex-memory.local.md" },
+    { "command": "bash .../prompt-recall.sh" }
+  ]
+}
+```
+
+**Pi Extension (`~/.pi/agent/extensions/cortex.ts`):**
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execSync } from "node:child_process";
+
+export default function (pi: ExtensionAPI) {
+  const CORTEX_DIR = "/path/to/cortex/engine";
+
+  // SessionStart → session_start
+  pi.on("session_start", async (_event, _ctx) => {
+    try {
+      execSync(`bash ${CORTEX_DIR}/hooks/scripts/load-surface.sh`, {
+        timeout: 30_000,
+      });
+    } catch {}
+  });
+
+  // SessionEnd → session_shutdown
+  pi.on("session_shutdown", async (_event, _ctx) => {
+    try {
+      execSync(`bash ${CORTEX_DIR}/hooks/scripts/extract-and-generate.sh`, {
+        timeout: 300_000,
+      });
+    } catch {}
+  });
+
+  // UserPromptSubmit → before_agent_start (inject context)
+  pi.on("before_agent_start", async (_event, _ctx) => {
+    let extra = "";
+    try {
+      extra = execSync("cat .claude/cortex-memory.local.md 2>/dev/null || true").toString();
+    } catch {}
+    try {
+      extra += execSync(`bash ${CORTEX_DIR}/hooks/scripts/prompt-recall.sh`, {
+        timeout: 5_000,
+      }).toString();
+    } catch {}
+
+    if (extra.trim()) {
+      return {
+        message: {
+          customType: "cortex-memory",
+          content: extra,
+          display: false,
+        },
+      };
+    }
+  });
+}
+```
+
+### Example: PreToolUse Guards → Extension
+
+**Claude Code (`hooks.json`):**
+```json
+{
+  "PreToolUse": [
+    { "matcher": "Edit", "command": "bash .../block-direct-edits.sh" },
+    { "matcher": "Write", "command": "bash .../block-direct-edits.sh" },
+    { "matcher": "Bash", "command": "bash .../guard-state-file.sh" }
+  ]
+}
+```
+
+**Pi Extension (`~/.pi/agent/extensions/loom-guards.ts`):**
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
+import { execSync } from "node:child_process";
+
+export default function (pi: ExtensionAPI) {
+  const LOOM_DIR = "..."; // resolve dynamically or hardcode
+
+  pi.on("tool_call", async (event, ctx) => {
+    // Block direct edits during loom orchestration
+    if (isToolCallEventType("edit", event) || isToolCallEventType("write", event)) {
+      try {
+        const result = execSync(
+          `bash ${LOOM_DIR}/hooks/scripts/block-direct-edits.sh`,
+        ).toString();
+        if (result.includes("BLOCK")) {
+          return { block: true, reason: "Direct edits blocked during Loom orchestration" };
+        }
+      } catch {
+        return { block: true, reason: "Edit guard script failed" };
+      }
+    }
+
+    // Guard state file on bash commands
+    if (isToolCallEventType("bash", event)) {
+      try {
+        execSync(`bash ${LOOM_DIR}/hooks/scripts/guard-state-file.sh`);
+      } catch {
+        return { block: true, reason: "State file guard triggered" };
+      }
+    }
+  });
+}
+```
+
+### Example: Permission Gates (replacing `settings.local.json` allow rules)
+
+**Claude Code (`.claude/settings.local.json`):**
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git push:*)",
+      "Bash(gh pr:*)"
+    ]
+  }
+}
+```
+
+**Pi Extension (`~/.pi/agent/extensions/permissions.ts`):**
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  const ALLOWED_PATTERNS = [/^git push/, /^gh pr/];
+
+  pi.on("tool_call", async (event, ctx) => {
+    if (isToolCallEventType("bash", event)) {
+      const cmd = event.input.command;
+
+      // Auto-allow matching patterns
+      if (ALLOWED_PATTERNS.some((p) => p.test(cmd))) {
+        return; // allow
+      }
+
+      // Block dangerous commands
+      if (cmd.includes("rm -rf") || cmd.includes("sudo")) {
+        const ok = await ctx.ui.confirm("Dangerous Command", `Allow: ${cmd}?`);
+        if (!ok) return { block: true, reason: "Blocked by user" };
+      }
+    }
+  });
+}
+```
+
+### Hook → Event Quick Reference
+
+```
+Claude Code                          Pi Extension
+──────────────────────────────────── ────────────────────────────────────
+PreToolUse + matcher "Bash"     →   pi.on("tool_call", ...) + isToolCallEventType("bash", event)
+PreToolUse + matcher "Edit"     →   pi.on("tool_call", ...) + isToolCallEventType("edit", event)
+PreToolUse + matcher "Write"    →   pi.on("tool_call", ...) + isToolCallEventType("write", event)
+PreToolUse + matcher "Read"     →   pi.on("tool_call", ...) + isToolCallEventType("read", event)
+PreToolUse + matcher "Task"     →   No built-in Task tool; build custom tool via pi.registerTool()
+PostToolUse                     →   pi.on("tool_result", ...)
+SessionStart                    →   pi.on("session_start", ...)
+SessionEnd                      →   pi.on("session_shutdown", ...)
+UserPromptSubmit                →   pi.on("input", ...) for transform/intercept
+                                    pi.on("before_agent_start", ...) for context injection
+SubagentStart                   →   Custom tool + pi.exec() or tmux spawn
+SubagentStop                    →   Custom tool result handler
+```
+
+---
+
+## 4. Plugins → Pi Packages
+
+Claude Code plugins bundle commands + hooks + skills into installable packages. Pi has an equivalent: **pi packages** — npm or git repos that bundle extensions, skills, prompts, and themes.
+
+**Yes, you can bundle everything into one package.** A pi package can contain extensions, skills, prompts, themes, and any supporting files (agents, rules, references, engine code). The extension code can reference sibling files in the package using `import.meta.url`.
+
+### Package Manifest
+
+Pi packages declare resources in `package.json` under the `pi` key:
+
+```json
+{
+  "name": "loom-pi-package",
+  "version": "1.0.0",
+  "keywords": ["pi-package"],
+  "pi": {
+    "extensions": ["./extensions"],
+    "skills": ["./skills"],
+    "prompts": ["./prompts"]
+  },
+  "dependencies": {
+    "ts-pattern": "^5.0.0"
+  }
+}
+```
+
+The `pi` manifest supports four resource types: `extensions`, `skills`, `prompts`, `themes`. Each is an array of paths (directories or files, supports globs).
+
+**Without a `pi` manifest**, pi auto-discovers from conventional directories: `extensions/`, `skills/`, `prompts/`, `themes/`.
+
+### What About Agents, Rules, References, Engine?
+
+Pi packages only auto-discover the four resource types above. But agents, rules, references, and engine code **don't need auto-discovery** — they're referenced by your extension code and skill/agent content via paths.
+
+Two approaches:
+
+**Approach 1: Extension discovers agents/rules via `resources_discover` + `import.meta.url`**
+
+Your extension can dynamically contribute skill paths and use its own directory as the base:
+
+```typescript
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const PACKAGE_ROOT = dirname(fileURLToPath(import.meta.url));
+
+export default function (pi: ExtensionAPI) {
+  // Dynamically contribute skills from this package
+  pi.on("resources_discover", () => ({
+    skillPaths: [
+      join(PACKAGE_ROOT, "../skills"),  // relative to extension file
+    ],
+    promptPaths: [
+      join(PACKAGE_ROOT, "../prompts"),
+    ],
+  }));
+
+  // Import engine code directly (it's in the same package)
+  // import { StateManager } from "../engine/src/state-manager";
+  // import { PHASE_ORDER } from "../engine/src/config";
+}
+```
+
+**Approach 2: Agents/rules are just files that skills and agent definitions tell the model to `read`**
+
+Skill content and agent system prompts reference files by path. The model uses the `read` tool to load them on demand. Just include the files in your package and reference them:
+
+```markdown
+<!-- In a skill SKILL.md or agent .md -->
+**Always read before reviewing:**
+- `~/.pi/agent/agents/rules/architecture.md`
+- `~/.pi/agent/agents/rules/typescript-patterns.md`
+```
+
+For a self-contained package, the subagent extension's agent discovery loads agents from `~/.pi/agent/agents/` (user) and `.pi/agents/` (project). Copy your agents there, or extend the discovery in your extension.
+
+### Full Loom Package Structure
+
+```
+loom-pi/
+├── package.json              # pi manifest + dependencies
+├── extensions/
+│   └── index.ts              # Main extension (hooks, tools, commands)
+├── agents/                   # Subagent definitions (loaded by subagent tool)
+│   ├── architecture-agent.md
+│   ├── code-implementer-agent.md
+│   ├── code-reviewer.md
+│   └── ...21 agents
+├── rules/                    # Reference docs (read by agents on demand)
+│   ├── architecture.md
+│   ├── java-patterns.md
+│   ├── typescript-patterns.md
+│   ├── property-testing.md
+│   └── rust-patterns.md
+├── skills/                   # Auto-discovered by pi
+│   ├── loom/
+│   │   ├── SKILL.md          # Main /skill:loom entry point
+│   │   ├── templates/
+│   │   └── references/
+│   ├── nextjs-frontend-design/
+│   │   └── SKILL.md
+│   └── vercel-react-best-practices/
+│       └── SKILL.md
+├── prompts/                  # Auto-discovered by pi
+│   ├── clarify.md
+│   ├── brainstorming.md
+│   ├── review-pr.md
+│   ├── wave-gate.md
+│   └── ...more commands
+└── engine/                   # Engine code (imported by extension)
+    ├── src/
+    │   ├── cli.ts
+    │   ├── config.ts
+    │   ├── types.ts
+    │   ├── state-manager.ts
+    │   ├── handlers/
+    │   ├── parsers/
+    │   └── utils/
+    └── package.json
+```
+
+**`package.json`:**
+```json
+{
+  "name": "@peterstorm/loom",
+  "version": "1.0.0",
+  "keywords": ["pi-package"],
+  "type": "module",
+  "pi": {
+    "extensions": ["./extensions"],
+    "skills": ["./skills"],
+    "prompts": ["./prompts"]
+  },
+  "dependencies": {
+    "ts-pattern": "^5.0.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
+  }
+}
+```
+
+The extension imports engine code directly:
+
+```typescript
+// extensions/index.ts
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
+
+const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const AGENTS_DIR = join(PACKAGE_ROOT, "agents");
+const RULES_DIR = join(PACKAGE_ROOT, "rules");
+
+// Import engine code directly — no shell wrappers needed
+// import { StateManager } from "../engine/src/state-manager";
+// import { PHASE_ORDER, PHASE_AGENT_MAP } from "../engine/src/config";
+
+export default function (pi: ExtensionAPI) {
+  // Hook: tool_call guards
+  pi.on("tool_call", async (event, ctx) => {
+    // ... validation logic using engine imports directly
+  });
+
+  // Hook: session lifecycle
+  pi.on("session_start", async (event, ctx) => {
+    // ... cleanup stale state
+  });
+
+  // Custom command: /loom-status
+  pi.registerCommand("loom-status", {
+    description: "Show current loom orchestration status",
+    handler: async (args, ctx) => {
+      // ... read state file, show status
+    },
+  });
+}
+```
+
+### Installing Packages
+
+```bash
+# From git (your loom repo)
+pi install git:github.com/peterstorm/loom
+
+# From git with pinned version
+pi install git:github.com/peterstorm/loom@v1.0.0
+
+# From npm
+pi install npm:@peterstorm/loom
+
+# Local path (for development — no copy, references in-place)
+pi install ./path/to/loom-pi
+
+# Quick test without installing
+pi -e ./extensions/index.ts --skill ./skills/loom
+
+# Manage
+pi list                     # show installed packages
+pi config                   # enable/disable specific resources
+pi update                   # update all packages
+pi remove git:github.com/peterstorm/loom
+```
+
+Project-local install (writes to `.pi/settings.json`, shared with team):
+```bash
+pi install -l git:github.com/peterstorm/loom
+```
+
+### Package Filtering
+
+Users can selectively enable/disable parts of your package:
+
+```json
+{
+  "packages": [
+    {
+      "source": "git:github.com/peterstorm/loom",
+      "extensions": ["extensions/*.ts"],
+      "skills": ["skills/loom"],
+      "prompts": []
+    }
+  ]
+}
+```
+
+### Or Just Use Local Directories
+
+If you don't need to distribute, just place files directly:
+
+```
+~/.pi/agent/
+├── extensions/
+│   ├── cortex.ts
+│   └── loom/
+│       └── index.ts
+├── agents/                   # Loaded by subagent extension
+│   ├── architecture-agent.md
+│   ├── code-reviewer.md
+│   └── ...
+├── rules/                    # Read by agents on demand
+│   ├── architecture.md
+│   └── ...
+├── skills/
+│   ├── loom/
+│   │   └── SKILL.md
+│   └── impeccable/
+│       └── SKILL.md
+└── prompts/
+    ├── feynman.md
+    ├── clarify.md
+    └── brainstorming.md
+```
+
+---
+
+## 5. Marketplace Skills
+
+Claude Code marketplace skills that follow the [Agent Skills standard](https://agentskills.io) (i.e., have `SKILL.md` with frontmatter) work in pi as-is.
+
+### Option A: Point pi at existing Claude Code skills
+
+Add to `~/.pi/agent/settings.json`:
+
+```json
+{
+  "skills": [
+    "~/.claude/plugins/cache/impeccable/impeccable/3.0.7/skills",
+    "~/.claude/plugins/cache/frontend-slides/frontend-slides/1.0.0/skills"
+  ]
+}
+```
+
+### Option B: Copy into pi's skills directory
+
+```bash
+cp -r ~/.claude/plugins/cache/impeccable/impeccable/3.0.7/skills/impeccable \
+   ~/.pi/agent/skills/impeccable
+
+cp -r ~/.claude/plugins/cache/frontend-slides/frontend-slides/1.0.0/skills/* \
+   ~/.pi/agent/skills/
+```
+
+### Using skills from other harnesses
+
+Pi natively supports loading skills from Claude Code or OpenAI Codex directories:
+
+```json
+{
+  "skills": [
+    "~/.claude/skills",
+    "~/.codex/skills"
+  ]
+}
+```
+
+---
+
+## 6. Settings
+
+### Claude Code → Pi Settings Map
+
+| Claude Code Setting | Pi Equivalent |
+|---|---|
+| `"model": "opus[1m]"` | `pi --model opus --thinking high` or `/model` + `/settings` |
+| `"effortLevel": "high"` | `--thinking high` or Shift+Tab to cycle |
+| `"autoCompactEnabled": true` | Enabled by default |
+| `"statusLine": { "command": "..." }` | `ctx.ui.setStatus()` in extension |
+| `"enabledPlugins": { ... }` | Auto-discovered; toggle with `pi config` |
+| `"env": { "KEY": "val" }` | Set in shell or `.env` |
+| `"permissions.allow"` | Extension with `tool_call` event handler |
+
+### Pi Settings File
+
+**Global:** `~/.pi/agent/settings.json`
+**Project:** `.pi/settings.json`
+
+```json
+{
+  "skills": [
+    "~/.claude/skills"
+  ],
+  "extensions": [
+    "/path/to/extra/extension.ts"
+  ]
+}
+```
+
+Use `/settings` in interactive mode for common options (thinking level, theme, etc.).
+
+---
+
+## 7. Quick Start Migration Steps
+
+```bash
+# 1. Create pi directories
+mkdir -p ~/.pi/agent/{extensions,skills,prompts}
+
+# 2. Copy simple commands as prompt templates
+# Note: Use the repo version (~/dev/claude-plugins/loom), NOT the installed
+# cache — the repo is newer and self-contained with ${CLAUDE_PLUGIN_ROOT} paths
+LOOM_REPO=~/dev/claude-plugins/loom
+
+cp ~/.claude/plugins/cache/plugins/feynman/0.1.0/commands/feynman.md \
+   ~/.pi/agent/prompts/
+cp $LOOM_REPO/commands/clarify.md \
+   ~/.pi/agent/prompts/
+cp $LOOM_REPO/commands/brainstorming.md \
+   ~/.pi/agent/prompts/
+cp $LOOM_REPO/commands/review-pr.md \
+   ~/.pi/agent/prompts/
+cp $LOOM_REPO/commands/wave-gate.md \
+   ~/.pi/agent/prompts/
+
+# 3. Copy complex skills (repo already has proper skills/ structure)
+mkdir -p ~/.pi/agent/skills/loom
+cp $LOOM_REPO/commands/loom.md \
+   ~/.pi/agent/skills/loom/SKILL.md
+cp -r $LOOM_REPO/commands/templates \
+   ~/.pi/agent/skills/loom/
+cp -r $LOOM_REPO/engine \
+   ~/.pi/agent/skills/loom/
+cp -r $LOOM_REPO/references \
+   ~/.pi/agent/skills/loom/
+cp -r $LOOM_REPO/rules \
+   ~/.pi/agent/skills/loom/
+
+# Copy bundled skills (already in skills/ with SKILL.md)
+cp -r $LOOM_REPO/skills/* ~/.pi/agent/skills/
+
+cp -r ~/.claude/plugins/cache/impeccable/impeccable/3.0.7/skills/impeccable \
+   ~/.pi/agent/skills/
+
+# 4. Copy agents (for subagent extension)
+mkdir -p ~/.pi/agent/agents
+cp $LOOM_REPO/agents/*.md ~/.pi/agent/agents/
+
+# 5. Copy cortex commands as prompt templates
+cp ~/.claude/plugins/cache/plugins/cortex/0.1.0/commands/remember.md \
+   ~/.pi/agent/prompts/
+cp ~/.claude/plugins/cache/plugins/cortex/0.1.0/commands/recall.md \
+   ~/.pi/agent/prompts/
+cp ~/.claude/plugins/cache/plugins/cortex/0.1.0/commands/forget.md \
+   ~/.pi/agent/prompts/
+cp ~/.claude/plugins/cache/plugins/cortex/0.1.0/commands/inspect.md \
+   ~/.pi/agent/prompts/
+
+# 5. Create extensions for hooks (see examples in section 3 above)
+# → ~/.pi/agent/extensions/cortex.ts
+# → ~/.pi/agent/extensions/loom-guards.ts
+
+# 6. Copy context files
+cp ~/.claude/CLAUDE.md ~/.pi/agent/AGENTS.md 2>/dev/null || true
+
+# 7. Verify
+pi  # Start pi, check startup header for loaded skills/extensions/prompts
+```
+
+---
+
+## 8. Sub-Agents
+
+Claude Code has a built-in `Task` tool for spawning sub-agents. Pi doesn't include this by default, but ships a **full subagent example extension** that's actually more capable:
+
+```
+examples/extensions/subagent/
+├── index.ts             # Extension entry point
+├── agents.ts            # Agent discovery logic
+├── agents/              # Agent definitions (markdown with frontmatter)
+│   ├── scout.md         # Fast recon (Haiku, read-only tools)
+│   ├── planner.md       # Implementation plans (Sonnet, read-only)
+│   ├── reviewer.md      # Code review (Sonnet)
+│   └── worker.md        # General-purpose (Sonnet, all tools)
+└── prompts/             # Workflow presets
+    ├── implement.md             # scout → planner → worker
+    ├── scout-and-plan.md        # scout → planner
+    └── implement-and-review.md  # worker → reviewer → worker
+```
+
+### Installation
+
+```bash
+# Copy the extension
+cp -r "$(dirname $(which pi))/../lib/node_modules/pi-monorepo/examples/extensions/subagent" \
+  ~/.pi/agent/extensions/subagent
+
+# Copy sample agents
+mkdir -p ~/.pi/agent/agents
+cp ~/.pi/agent/extensions/subagent/agents/*.md ~/.pi/agent/agents/
+
+# Copy workflow prompts
+mkdir -p ~/.pi/agent/prompts
+cp ~/.pi/agent/extensions/subagent/prompts/*.md ~/.pi/agent/prompts/
+```
+
+Or if installed via nix, symlink from the store path.
+
+### Features
+
+The subagent extension supports three modes:
+
+| Mode | Usage | Description |
+|------|-------|-------------|
+| **Single** | `{ agent: "scout", task: "find auth code" }` | One agent, one task |
+| **Parallel** | `{ tasks: [{agent, task}, ...] }` | Up to 8 tasks, 4 concurrent |
+| **Chain** | `{ chain: [{agent, task}, ...] }` | Sequential with `{previous}` placeholder |
+
+Each subagent spawns a separate `pi` process with isolated context. Features include:
+- **Streaming output** — see tool calls and progress as they happen
+- **Parallel streaming** — all parallel tasks stream updates simultaneously
+- **Usage tracking** — turns, tokens, cost, and context usage per agent
+- **Abort support** — Ctrl+C propagates to kill subagent processes
+- **Agent scoping** — user-level (`~/.pi/agent/agents/`) and project-level (`.pi/agents/`)
+- **Security confirmation** — prompts before running project-local agents
+
+### Defining Custom Agents
+
+Agents are markdown files with YAML frontmatter placed in `~/.pi/agent/agents/` (global) or `.pi/agents/` (project-local):
+
+```markdown
+---
+name: my-agent
+description: What this agent does
+tools: read, grep, find, ls
+model: claude-haiku-4-5
+---
+
+System prompt for the agent goes here.
+Be concise. Focus on X.
+```
+
+### Workflow Prompts
+
+Use prompt templates to define multi-agent workflows:
+
+```markdown
+<!-- ~/.pi/agent/prompts/implement.md -->
+Use a chain of subagents:
+1. scout: Find all relevant code for: {{task}}
+2. planner: Create implementation plan based on {previous}
+3. worker: Implement the plan from {previous}
+```
+
+Then invoke with `/implement add Redis caching to the session store`.
+
+### Mapping Loom Sub-Agents
+
+Your Loom plugin's sub-agent orchestration maps well to this extension:
+
+| Loom Concept | Pi Subagent Equivalent |
+|---|---|
+| `Task` tool call with agent | `subagent` tool with `{ agent, task }` |
+| Wave-based parallel execution | `{ tasks: [...] }` parallel mode |
+| Phase-ordered execution | `{ chain: [...] }` chain mode |
+| Agent model selection | `model:` in agent frontmatter |
+| Agent skill/tool restrictions | `tools:` in agent frontmatter |
+| SubagentStart/Stop hooks | Not needed — extension handles lifecycle |
+| Dispatch/cleanup scripts | `session_start` / `session_shutdown` events |
+
+---
+
+## 9. Session File Format (JSONL Transcript Parsing)
+
+Both Claude Code and pi use **JSONL** (one JSON object per line), but the schemas differ. Since Loom parses agent transcripts heavily, here's the mapping.
+
+### Format Comparison
+
+| Aspect | Claude Code | Pi |
+|---|---|---|
+| Format | JSONL | JSONL |
+| Structure | Flat linked list (`parentUuid`) | Tree (`id`/`parentId`) with branching |
+| Location | `~/.claude/projects/<path>/<uuid>.jsonl` | `~/.pi/agent/sessions/<path>/<timestamp>_<uuid>.jsonl` |
+| Header | No dedicated header line | First line: `{"type":"session", "version":3, ...}` |
+| Entry linking | `parentUuid` / `uuid` | `id` (8-char hex) / `parentId` |
+| Branching | Separate files for subagents | In-place tree branching in single file |
+| Sub-agent sessions | `subagents/agent-<id>.jsonl` | Separate pi process, separate session file |
+
+### Claude Code Entry Types → Pi Entry Types
+
+| Claude Code `type` | Pi `type` | Notes |
+|---|---|---|
+| `"human"` / user turn | `"message"` with `message.role: "user"` | |
+| `"assistant"` / assistant turn | `"message"` with `message.role: "assistant"` | |
+| `"tool_use"` / `"tool_result"` | `"message"` with `message.role: "toolResult"` | Tool calls are inline in assistant content |
+| `"attachment"` | No direct equivalent | Use `"custom_message"` or `"custom"` |
+| `"queue-operation"` | No equivalent | Pi uses message queue differently |
+| `"agent_listing_delta"` | No equivalent | Pi discovers agents at runtime |
+| (subagent session file) | Separate pi session file | Subagent output captured in tool result |
+
+### Pi Session Entry Structure
+
+Every pi entry (except the header) has:
+
+```typescript
+{
+  type: string;           // "message", "compaction", "model_change", etc.
+  id: string;             // 8-char hex ID
+  parentId: string | null; // Parent entry (null for first)
+  timestamp: string;      // ISO timestamp
+  // ...type-specific fields
+}
+```
+
+### Pi Message Roles
+
+```typescript
+type AgentMessage =
+  | UserMessage            // role: "user"
+  | AssistantMessage       // role: "assistant" (includes tool calls inline)
+  | ToolResultMessage      // role: "toolResult"
+  | BashExecutionMessage   // role: "bashExecution" (user ! commands)
+  | CustomMessage          // role: "custom" (extension-injected)
+  | BranchSummaryMessage   // role: "branchSummary"
+  | CompactionSummaryMessage // role: "compactionSummary"
+```
+
+### Key Differences for Transcript Parsing
+
+**Tool calls are embedded in assistant messages**, not separate entries:
+
+```json
+{"type":"message","id":"b2c3d4e5","parentId":"a1b2c3d4","message":{
+  "role":"assistant",
+  "content":[
+    {"type":"text","text":"Let me check that file."},
+    {"type":"toolCall","id":"call_123","name":"read","arguments":{"path":"src/main.ts"}}
+  ],
+  "provider":"anthropic","model":"claude-sonnet-4-5",
+  "usage":{"input":1000,"output":200,"cacheRead":500,"cacheWrite":0,"totalTokens":1700,
+    "cost":{"input":0.003,"output":0.006,"cacheRead":0.0005,"cacheWrite":0,"total":0.0095}},
+  "stopReason":"toolUse"
+}}
+```
+
+**Tool results are separate message entries** linked by `toolCallId`:
+
+```json
+{"type":"message","id":"c3d4e5f6","parentId":"b2c3d4e5","message":{
+  "role":"toolResult","toolCallId":"call_123","toolName":"read",
+  "content":[{"type":"text","text":"file contents..."}],
+  "details":{},"isError":false
+}}
+```
+
+**Tree structure** means you need to follow `parentId` to get the active branch:
+
+```typescript
+// Walk from leaf to root to get the active conversation
+function getActiveBranch(entries: any[], leafId: string): any[] {
+  const byId = new Map(entries.map(e => [e.id, e]));
+  const branch: any[] = [];
+  let current = byId.get(leafId);
+  while (current) {
+    branch.unshift(current);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  return branch;
+}
+```
+
+### Parsing Example (for Loom transcript analysis)
+
+```typescript
+import { readFileSync } from "fs";
+
+const lines = readFileSync("session.jsonl", "utf8").trim().split("\n");
+const entries = lines.map(l => JSON.parse(l));
+
+// Skip header
+const header = entries[0]; // type: "session"
+const dataEntries = entries.slice(1);
+
+// Find the leaf (last entry)
+const leaf = dataEntries[dataEntries.length - 1];
+
+// Extract conversation messages
+for (const entry of dataEntries) {
+  if (entry.type !== "message") continue;
+  const msg = entry.message;
+
+  switch (msg.role) {
+    case "user":
+      console.log(`USER: ${typeof msg.content === "string" ? msg.content : msg.content.map(c => c.text).join("")}`);  
+      break;
+    case "assistant":
+      const text = msg.content.filter(c => c.type === "text").map(c => c.text).join("");
+      const toolCalls = msg.content.filter(c => c.type === "toolCall");
+      if (text) console.log(`ASSISTANT: ${text}`);
+      for (const tc of toolCalls) {
+        console.log(`  TOOL_CALL: ${tc.name}(${JSON.stringify(tc.arguments)})`);
+      }
+      // Usage info:
+      console.log(`  tokens: ${msg.usage.totalTokens}, cost: $${msg.usage.cost.total}`);
+      break;
+    case "toolResult":
+      const output = msg.content.map(c => c.text).join("");
+      console.log(`  TOOL_RESULT [${msg.toolName}]: ${output.slice(0, 100)}...`);
+      break;
+  }
+}
+```
+
+### Using SessionManager API (from Extensions)
+
+If your Loom extension runs inside pi, you can skip raw JSONL parsing and use the typed API:
+
+```typescript
+pi.on("agent_end", async (event, ctx) => {
+  // Get all entries on the active branch
+  const branch = ctx.sessionManager.getBranch();
+  
+  // Get full context as the LLM sees it
+  const { messages, thinkingLevel, model } = ctx.sessionManager.buildSessionContext();
+  
+  // Iterate messages with full typing
+  for (const msg of messages) {
+    if (msg.role === "assistant") {
+      for (const part of msg.content) {
+        if (part.type === "toolCall") {
+          console.log(`Tool: ${part.name}, args: ${JSON.stringify(part.arguments)}`);
+        }
+      }
+    }
+  }
+});
+```
+
+See [session-format.md](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/session-format.md) for the complete specification.
+
+---
+
+## Key Differences
+
+| Feature | Claude Code | Pi |
+|---|---|---|
+| **Hooks** | Shell scripts via JSON config | TypeScript extensions with event handlers |
+| **Sub-agents** | Built-in `Task` tool | Not built-in — build with extensions (spawn pi via tmux, `pi.exec()`) |
+| **Permissions** | `settings.local.json` allow/deny rules | Extensions with `tool_call` event blocking |
+| **Commands** | `.md` files in `commands/` | Prompt templates, skills, or `pi.registerCommand()` |
+| **Plugins** | Installed via marketplace | Pi packages via `pi install npm:` or `pi install git:` |
+| **MCP** | Built-in MCP server support | Not built-in — use extensions or CLI tools with skills |
+| **Plan mode** | Built-in | Not built-in — use skills, write plans to files, or build via extensions |
+| **Status line** | Shell command in settings | `ctx.ui.setStatus()` in extension |
+| **Custom UI** | Limited | Full TUI components via `ctx.ui.custom()` |
+| **Hot reload** | Restart required | `/reload` reloads extensions, skills, prompts, themes |
+
+### Advantages of Pi's Approach
+
+- **TypeScript extensions** are more powerful than shell script hooks — full access to session state, UI, model info
+- **Event chaining** — multiple extensions can handle the same event, each seeing the result of previous handlers
+- **Custom tools** — register tools the LLM can call, not just intercept existing ones
+- **Custom UI** — build interactive wizards, selectors, status bars
+- **Hot reload** — `/reload` picks up changes without restarting
+- **Composable** — extensions, skills, prompts, and themes can be bundled into shareable packages
+
+### Migration Effort by Plugin
+
+| Plugin | Effort | Notes |
+|---|---|---|
+| **feynman** | Low | Single command → prompt template, copy the `.md` |
+| **cortex** | Medium | Hooks → extension, commands → prompts, engine scripts stay as-is |
+| **loom** | High | Heavy hook usage, sub-agent orchestration, engine CLI — needs extension rewrite |
+| **impeccable** | Low | Already Agent Skills standard, just copy or point settings |
+| **frontend-slides** | Low | Already Agent Skills standard, just copy or point settings |
+
+---
+
+## Appendix: Loom Plugin Deep Dive
+
+Loom is the most complex plugin to migrate. This section inventories every component and maps it to pi.
+
+### Full Component Inventory
+
+#### Agents (21 agent definitions)
+
+Claude Code agent definitions in `agents/*.md` — these are markdown files with YAML frontmatter (`name`, `description`, `model`, `color`, `skills`) and a system prompt body.
+
+| Agent | Role | Claude Code Model | Pi Equivalent |
+|---|---|---|---|
+| `architecture-agent` | Architectural design | opus | Pi subagent agent definition |
+| `adr-writer-agent` | Write Architecture Decision Records | (default) | Pi subagent agent definition |
+| `architecture-tech-lead` | Architectural review | (default) | Pi subagent agent definition |
+| `brainstorm-agent` | Exploration/ideation | (default) | Pi subagent agent definition |
+| `clarify-agent` | Resolve ambiguity | (default) | Pi subagent agent definition |
+| `code-implementer-agent` | Implementation (Java/TS) | sonnet | Pi subagent agent definition |
+| `code-reviewer` | Code review | (default) | Pi subagent agent definition |
+| `code-simplifier` | Code simplification | (default) | Pi subagent agent definition |
+| `comment-analyzer` | Comment quality | (default) | Pi subagent agent definition |
+| `decompose-agent` | Task decomposition | (default) | Pi subagent agent definition |
+| `frontend-agent` | Next.js frontend | (default) | Pi subagent agent definition |
+| `plan-alignment-agent` | Plan vs spec gaps | (default) | Pi subagent agent definition |
+| `pr-test-analyzer` | PR test coverage | (default) | Pi subagent agent definition |
+| `security-agent` | Security analysis | (default) | Pi subagent agent definition |
+| `silent-failure-hunter` | Error handling gaps | (default) | Pi subagent agent definition |
+| `skill-content-reviewer` | Skill quality review | (default) | Pi subagent agent definition |
+| `spec-check-invoker` | Spec alignment check | (default) | Pi subagent agent definition |
+| `specify-agent` | Formal specification | (default) | Pi subagent agent definition |
+| `test-engineer` | Test writing/fixing | (default) | Pi subagent agent definition |
+| `ts-test-agent` | TypeScript testing | (default) | Pi subagent agent definition |
+| `type-design-analyzer` | Type design review | (default) | Pi subagent agent definition |
+| `dotfiles-agent` | Dotfiles management | (default) | Dropped in repo version (commit `22ee2f4`) |
+
+**Migration:** Copy to `~/.pi/agent/agents/` and adapt frontmatter:
+
+```markdown
+<!-- Claude Code format (agents/code-implementer-agent.md) -->
+---
+name: code-implementer-agent
+description: Implementation agent for Java/Spring Boot or TypeScript/Next.js
+model: sonnet
+color: blue
+skills:
+  - code-implementer
+---
+System prompt here...
+```
+
+```markdown
+<!-- Pi format (~/.pi/agent/agents/code-implementer-agent.md) -->
+---
+name: code-implementer-agent
+description: Implementation agent for Java/Spring Boot or TypeScript/Next.js
+model: claude-sonnet-4-5
+tools: read, write, edit, bash, grep, find, ls
+---
+System prompt here...
+
+Preloaded skill content (inline the skill content since pi agents don't auto-load skills):
+...
+```
+
+**Key difference:** Claude Code agents have `skills:` that auto-preload skill content. Pi subagent agents don't — you need to either inline the skill content in the system prompt, or have the agent use `read` to load it.
+
+#### Commands (10 slash commands)
+
+| Command | Type | Pi Target |
+|---|---|---|
+| `/loom` | Main orchestration entry | **Skill** (`~/.pi/agent/skills/loom/SKILL.md`) |
+| `/wave-gate` | Wave completion gate | **Prompt template** or **skill** |
+| `/review-pr` | PR review workflow | **Prompt template** |
+| `/clarify` | Clarification phase | **Prompt template** |
+| `/brainstorming` | Brainstorm phase | **Prompt template** |
+| `/specify` | Specification phase | **Prompt template** |
+| `/code-implementer` | Implementation prompt | **Prompt template** |
+| `/spec-check` | Spec alignment check | **Prompt template** or **skill** |
+| `/architecture-tech-lead` | Architecture review | **Prompt template** |
+
+#### Command Templates (7 phase templates)
+
+Used internally by the loom orchestration flow, referenced from `loom.md`:
+
+| Template | Purpose |
+|---|---|
+| `phase-brainstorm.md` | Brainstorm phase instructions |
+| `phase-specify.md` | Specification phase instructions |
+| `phase-clarify.md` | Clarification phase instructions |
+| `phase-architecture.md` | Architecture phase instructions |
+| `phase-plan-alignment.md` | Plan alignment phase instructions |
+| `phase-decompose.md` | Decomposition phase instructions |
+| `impl-agent-context.md` | Implementation agent context injection |
+
+**Migration:** These are internal templates referenced by the loom skill. Copy into the loom skill directory:
+```
+~/.pi/agent/skills/loom/
+├── SKILL.md
+├── templates/
+│   ├── phase-brainstorm.md
+│   ├── phase-specify.md
+│   └── ...
+```
+
+#### Skills (repo-level, 6 + 2 in commands/)
+
+The repo contains 6 skills in `skills/` that agents preload via their `skills:` frontmatter:
+
+| Skill | Purpose | Used by |
+|---|---|---|
+| `architecture-tech-lead` | Architecture review patterns | `architecture-agent`, `architecture-tech-lead` agent |
+| `code-implementer` | FP/DDD implementation patterns | `code-implementer-agent` |
+| `java-test-engineer` | Java testing patterns (JUnit, jqwik, Testcontainers) | `java-test-agent` |
+| `ts-test-engineer` | TypeScript testing (Vitest, RTL, Playwright) | `ts-test-agent` |
+| `security-expert` | Security analysis patterns | `security-agent` |
+| `nextjs-frontend-design` | Next.js/React design patterns | `frontend-agent` |
+
+Plus 2 embedded skills in `commands/`:
+
+| Skill | Purpose |
+|---|---|
+| `nextjs-frontend-design` | Next.js/React design patterns (duplicate of above) |
+| `vercel-react-best-practices` | Vercel React performance rules |
+
+**Migration:** Already Agent Skills format. Copy to `~/.pi/agent/skills/`.
+
+#### Rules (5 rule files)
+
+Claude Code rules with `globs:` frontmatter — these inject into context for matching files:
+
+| Rule | Applies to |
+|---|---|
+| `architecture.md` | `**/*.{ts,tsx,js,jsx,java,kt,hs,scala,rs}` |
+| `java-patterns.md` | `**/*.{java}` |
+| `typescript-patterns.md` | `**/*.{ts,tsx}` |
+| `property-testing.md` | `**/*.test.*` |
+| `rust-patterns.md` | `**/*.rs` |
+
+**Migration:** These are just **reference files that agents tell the model to `read`** — the agent body says things like:
+
+```markdown
+**Always read:**
+- `${CLAUDE_PLUGIN_ROOT}/rules/architecture.md`
+
+**Java** (*.java):
+- `${CLAUDE_PLUGIN_ROOT}/rules/java-patterns.md`
+```
+
+Note: There are **two versions** of the rule paths in the wild:
+- **Repo (dev, newer — use this):** `${CLAUDE_PLUGIN_ROOT}/rules/` — self-contained copies bundled in the plugin (commit `22ee2f4` refactored to this)
+- **Installed (cached, older):** `~/.dotfiles/claude/project/*/rules/` — references external dotfiles
+
+The repo version (`dev/claude-plugins/loom`) is 19 commits ahead of the installed version and is already **self-contained** — it bundles rules, skills, and references with `${CLAUDE_PLUGIN_ROOT}/` relative paths. **Port from the repo version**, not the installed cache.
+
+Pi works exactly the same way — agents tell the model to `read` files at paths, and the model uses the `read` tool.
+
+**For the pi package, replace `${CLAUDE_PLUGIN_ROOT}` with the package root path:**
+
+In your extension, resolve the package root:
+```typescript
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+```
+
+Then update agent system prompts. Since agents are markdown files loaded by the subagent extension, you can either:
+
+**Option A: Use absolute paths (simplest)**
+```markdown
+<!-- Agent system prompt references rules at known location -->
+**Always read:**
+- `~/.pi/agent/rules/architecture.md`
+```
+
+**Option B: Keep `${CLAUDE_PLUGIN_ROOT}` and resolve in extension**
+
+Your extension can resolve `${CLAUDE_PLUGIN_ROOT}` in agent system prompts before passing them to the subagent:
+
+```typescript
+// In your custom agent loader, replace the variable:
+const systemPrompt = raw.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, PACKAGE_ROOT);
+```
+
+**Option C: Dotfiles references still work**
+
+If you prefer keeping `~/.dotfiles/claude/...` paths (e.g., for a shared source of truth across tools), pi's `read` tool can access them just fine. No migration needed for the paths themselves.
+
+#### References (3 reference docs)
+
+| File | Purpose |
+|---|---|
+| `plan-template.md` | Template for architecture plans |
+| `spec-template.md` | Template for specifications |
+| `design-functional-evaluator.md` | Functional design evaluation criteria |
+
+**Migration:** Copy into the loom skill directory. Referenced by agents via relative paths.
+
+#### Hooks → Extension (11 shell scripts, 27 TypeScript handlers)
+
+This is the most complex part. The hooks shell scripts are thin wrappers around the TypeScript engine CLI:
+
+```bash
+# Example: hooks/scripts/validate-phase-order.sh
+exec bun "$LOOM_DIR/engine/src/cli.ts" pre-tool-use validate-phase-order
+```
+
+**Hook categories and their pi equivalents:**
+
+| Hook Category | Scripts | Pi Event | Complexity |
+|---|---|---|---|
+| **PreToolUse validators** | 7 scripts | `pi.on("tool_call", ...)` | Medium |
+| **SubagentStop dispatch** | 1 script (routes to 5 handlers) | `pi.on("tool_result", ...)` on subagent tool | High |
+| **SubagentStart** | 1 script | Extension state tracking | Low |
+| **SessionStart** | 2 scripts (cleanup-stale-subagents, resume-after-clear) | `pi.on("session_start", ...)` | Low |
+
+**PreToolUse hooks → `tool_call` event:**
+
+| Hook | What it does | Pi mapping |
+|---|---|---|
+| `validate-phase-order` | Blocks Task calls if phase ordering violated | Block subagent tool if wrong phase |
+| `validate-task-execution` | Ensures task in execute phase matches graph | Check task ID against state |
+| `validate-template-substitution` | Blocks un-substituted `{LOOM_DIR}` in Task | Check for template vars in tool args |
+| `validate-agent-model` | Warns if agent model doesn't match config | Log warning on model mismatch |
+| `validate-agent-skill` | Warns if agent missing required skill | Log warning on missing skill |
+| `block-direct-edits` | Blocks Edit/Write during orchestration | Block edit/write tools when state active |
+| `guard-state-file` | Prevents direct state file writes | Block bash commands touching state |
+
+**SubagentStart hook → extension state:**
+
+| Hook | What it does | Pi mapping |
+|---|---|---|
+| `mark-subagent-active` | Writes flag file when subagent starts | Track in extension state or `pi.appendEntry()` |
+
+**SessionStart hooks → `session_start` event:**
+
+| Hook | What it does | Pi mapping |
+|---|---|---|
+| `cleanup-stale-subagents` | Removes orphaned subagent markers on startup | Cleanup in `session_start` handler |
+| `resume-after-clear` | Restores loom state after `/clear` | Restore state in `session_start` with `reason: "new"` |
+
+**SubagentStop hooks → `tool_result` event on subagent tool:**
+
+| Handler | What it does |
+|---|---|
+| `dispatch` | Routes by agent type to appropriate handler |
+| `advance-phase` | Moves phase forward after phase agents complete |
+| `update-task-status` | Marks tasks done/failed based on transcript |
+| `store-reviewer-findings` | Extracts review findings from transcript |
+| `store-spec-check-findings` | Extracts spec-check results from transcript |
+| `cleanup-subagent-flag` | Removes active subagent marker |
+
+#### Engine (TypeScript CLI + state management)
+
+The engine is a bun-based TypeScript CLI that all hooks call:
+
+```bash
+bun engine/src/cli.ts <hook-type> <handler-name> [args...]
+bun engine/src/cli.ts init-state --spec-dir <dir> --output <path>
+```
+
+**Components:**
+
+| Component | Purpose | Pi Migration |
+|---|---|---|
+| `cli.ts` | CLI entry point, routes to handlers | Replace with extension direct calls |
+| `state-manager.ts` | Atomic task graph JSON read/write with locking | Reuse as-is, or use `pi.appendEntry()` |
+| `config.ts` | Constants (phase order, agent maps, patterns) | Import directly into extension |
+| `types.ts` | TypeScript types (TaskGraph, Task, Phase, etc.) | Import directly into extension |
+| `phase-init.ts` | Initialize state for a new orchestration | Call from extension |
+| **Parsers** | | |
+| `parse-transcript.ts` | Extract text from Claude Code JSONL | **Must adapt for pi's JSONL format** |
+| `parse-bash-test-output.ts` | Detect test pass/fail from bash output | Reuse as-is |
+| `parse-files-modified.ts` | Extract modified files from transcript | **Must adapt for pi's format** |
+| `parse-phase-artifacts.ts` | Extract phase artifact paths | Reuse as-is |
+| **Utils** | | |
+| `read-transcript-with-retry.ts` | Retry-read transcript file | Adapt for pi session paths |
+| `git.ts` | Git operations (start SHA, diff) | Reuse as-is |
+| `lock.ts` | File locking for state writes | Reuse as-is |
+| `find-file.ts` | File discovery | Reuse as-is |
+| `extract-task-id.ts` | Parse task ID from agent input | Reuse as-is |
+| `strip-namespace.ts` | Strip `loom:` prefix from agent types | Reuse as-is |
+| **Helper handlers** (called by other handlers, not directly by hooks) | | |
+| `cleanup-state.ts` | Remove state file and subagent markers | Reuse as-is |
+| `complete-wave-gate.ts` | Mark a wave gate as complete | Reuse as-is |
+| `extract-task-id.ts` | Extract task ID from hook input | Reuse as-is |
+| `mark-tests-passed.ts` | Mark task tests as passed | Reuse as-is |
+| `populate-task-graph.ts` | Fill task graph from decompose output | Reuse as-is |
+| `set-phase.ts` | Advance to next phase | Reuse as-is |
+| `store-review-findings.ts` | Store code review findings in state | Reuse as-is |
+| `store-spec-check.ts` | Store spec-check results in state | Reuse as-is |
+| `store-test-evidence.ts` | Store test output evidence | Reuse as-is |
+| `suggest-spec-anchors.ts` | Suggest spec anchors for tasks | Reuse as-is |
+| `validate-task-graph.ts` | Validate task graph consistency | Reuse as-is |
+
+#### State File (`.claude/state/active_task_graph.json`)
+
+The task graph is a JSON file with chmod 444 protection:
+
+```typescript
+interface TaskGraph {
+  current_phase: Phase;  // "init" | "brainstorm" | ... | "execute"
+  phase_artifacts: Partial<Record<Phase, string>>;
+  skipped_phases: Phase[];
+  spec_file: string | null;
+  plan_file: string | null;
+  tasks: Task[];  // Array of {id, description, agent, wave, status, depends_on, ...}
+  current_wave?: number;
+  wave_gates: Record<string, WaveGate>;  // {impl_complete, tests_passed, reviews_complete}
+  github_issue?: number;
+  spec_check?: SpecCheck;
+}
+```
+
+**Migration:** The state file path changes from `.claude/state/` to `.pi/state/` (or keep it project-agnostic). The StateManager TypeScript class can be reused directly — just update the path constants in `config.ts`.
+
+Alternatively, use `pi.appendEntry()` to persist state in the session file itself, making it survive session switches. But the current file-based approach is simpler and works across subagent processes.
+
+### Transcript Parsing (Critical for Loom)
+
+Loom's engine parses Claude Code transcripts to extract:
+- Test pass/fail evidence from bash output
+- Files modified by subagents
+- Phase artifacts (spec, plan paths)
+
+The parsers in `engine/src/parsers/` assume Claude Code's JSONL format:
+
+```typescript
+// Claude Code format (parsers/types.ts)
+interface TranscriptLine {
+  message?: {
+    role?: string;
+    content?: string | ContentBlock[];  // tool_use, tool_result, text
+  };
+}
+```
+
+Pi's format is different (see [Section 9](#9-session-file-format-jsonl-transcript-parsing)):
+
+```typescript
+// Pi format
+interface PiEntry {
+  type: "message";
+  id: string;
+  parentId: string | null;
+  message: {
+    role: "user" | "assistant" | "toolResult";  // not tool_use/tool_result
+    content: (TextContent | ToolCall)[];  // toolCall inline in assistant
+  };
+}
+```
+
+**Key adapter changes needed:**
+
+1. **Tool calls** are `{ type: "toolCall", name, arguments }` inside assistant content (not `tool_use`)
+2. **Tool results** are separate entries with `role: "toolResult"` (not `tool_result` content blocks)
+3. **Tree structure** — must follow `parentId` chain, not just iterate lines
+4. **Subagent transcripts** — pi subagents produce their own session files; the subagent tool result contains the final output but not the full transcript. For full transcript parsing, read the subagent's session file.
+
+**Adapter pattern:**
+
+```typescript
+// Adapter: pi session → loom's expected format
+function piSessionToTranscript(sessionPath: string): string {
+  const lines = readFileSync(sessionPath, "utf8").trim().split("\n");
+  const texts: string[] = [];
+  
+  for (const line of lines) {
+    const entry = JSON.parse(line);
+    if (entry.type !== "message") continue;
+    const msg = entry.message;
+    
+    if (msg.role === "assistant") {
+      for (const block of msg.content) {
+        if (block.type === "text") texts.push(block.text);
+      }
+    } else if (msg.role === "toolResult") {
+      for (const block of msg.content) {
+        if (block.type === "text") texts.push(block.text);
+      }
+    }
+  }
+  
+  return texts.join("\n");
+}
+```
+
+Or if running inside a pi extension, use `ctx.sessionManager` directly instead of parsing files.
+
+### Migration Strategy for Loom
+
+#### Dual-Client Architecture (Claude Code + Pi from one repo)
+
+Most of loom is **pure business logic** that doesn't care which harness runs it. The handlers have a thin stdin/JSON parsing layer on top, but the core logic (phase validation, state management, task graph operations) is shared. Here's how to refactor for both clients:
+
+**What's already shared (no changes needed):**
+- `skills/` — Agent Skills standard works in both
+- `rules/` — Just `.md` files agents `read`
+- `references/` — Just `.md` files agents `read`
+- `commands/` — Prompt/skill content (`.md` files)
+- `agents/` — Agent definitions (frontmatter needs minor adaptation, see below)
+- `engine/src/types.ts` — Pure types
+- `engine/src/state-manager.ts` — File I/O with locking
+- `engine/src/phase-init.ts` — State initialization
+- `engine/src/utils/` — All utilities (git, lock, find-file, extract-task-id, strip-namespace)
+- `engine/src/parsers/parse-bash-test-output.ts` — Test output detection
+- `engine/src/parsers/parse-phase-artifacts.ts` — Phase artifact extraction
+- `engine/src/handlers/helpers/` — All 11 helper handlers (pure business logic)
+- `engine/tests/` — All tests
+
+**What's Claude Code only (keep as-is):**
+- `.claude-plugin/plugin.json`
+- `hooks/hooks.json` + `hooks/scripts/*.sh`
+- `engine/src/cli.ts` (bun CLI entry point)
+
+**What's pi only (add new):**
+- `package.json` with `pi` manifest
+- `pi/extension.ts` (thin adapter)
+
+**What needs a small refactor (extract core logic from handlers):**
+
+The handlers currently look like this:
+```typescript
+// engine/src/handlers/pre-tool-use/block-direct-edits.ts
+const handler: HookHandler = async (stdin) => {
+  const input: PreToolUseInput = JSON.parse(stdin);  // <-- Claude-specific
+  if (!FILE_TOOLS.has(input.tool_name)) return ...;   // <-- uses .tool_name
+  // ... core logic ...
+};
+```
+
+**Refactor: extract the core logic into a pure function, keep the stdin wrapper:**
+
+```typescript
+// engine/src/core/block-direct-edits.ts (NEW - shared)
+export function shouldBlockDirectEdit(toolName: string, sessionId: string): HookResult {
+  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
+  if (!FILE_TOOLS.has(toolName)) return { kind: "allow" };
+  // ... same logic ...
+}
+
+// engine/src/handlers/pre-tool-use/block-direct-edits.ts (Claude Code wrapper - unchanged)
+const handler: HookHandler = async (stdin) => {
+  const input: PreToolUseInput = JSON.parse(stdin);
+  return shouldBlockDirectEdit(input.tool_name, input.session_id);
+};
+
+// pi/extension.ts (Pi wrapper - new)
+pi.on("tool_call", async (event, ctx) => {
+  if (isToolCallEventType("edit", event) || isToolCallEventType("write", event)) {
+    const result = shouldBlockDirectEdit("Edit", sessionId);
+    if (result.kind === "block") return { block: true, reason: result.message };
+  }
+});
+```
+
+The same pattern applies to all handlers. The input fields map like this:
+
+| Claude Code (`PreToolUseInput`) | Pi (`tool_call` event) |
+|---|---|
+| `input.tool_name` ("Task", "Edit", "Bash") | `event.toolName` ("subagent", "edit", "bash") |
+| `input.tool_input.prompt` | `event.input.task` |
+| `input.tool_input.subagent_type` | `event.input.agent` |
+| `input.session_id` | `ctx.sessionManager.getSessionId()` |
+
+| Claude Code (`SubagentStopInput`) | Pi (`tool_result` event) |
+|---|---|
+| `input.agent_type` | `event.details.results[0].agent` |
+| `input.agent_transcript_path` | Subagent session file path |
+| `input.session_id` | `ctx.sessionManager.getSessionId()` |
+
+#### Proposed Repo Structure
+
+```
+loom/
+├── .claude-plugin/             # Claude Code plugin manifest
+│   └── plugin.json
+├── package.json                # Pi package manifest (pi key) + shared deps
+│
+├── agents/                     # SHARED - agent definitions
+│   ├── architecture-agent.md
+│   ├── code-reviewer.md
+│   └── ...21 agents
+│
+├── skills/                     # SHARED - Agent Skills standard
+│   ├── loom/SKILL.md
+│   ├── code-implementer/SKILL.md
+│   └── ...
+│
+├── commands/                   # SHARED - slash commands / prompts
+│   ├── loom.md
+│   ├── clarify.md
+│   └── templates/
+│
+├── rules/                      # SHARED - reference docs
+├── references/                 # SHARED - templates
+│
+├── engine/                     # SHARED core + client wrappers
+│   ├── src/
+│   │   ├── core/               # NEW - pure business logic (no stdin)
+│   │   │   ├── block-direct-edits.ts
+│   │   │   ├── guard-state-file.ts
+│   │   │   ├── validate-phase-order.ts
+│   │   │   ├── validate-task-execution.ts
+│   │   │   ├── validate-template-substitution.ts
+│   │   │   ├── validate-agent-model.ts
+│   │   │   ├── validate-agent-skill.ts
+│   │   │   ├── dispatch-subagent-stop.ts
+│   │   │   ├── on-session-start.ts
+│   │   │   └── on-subagent-start.ts
+│   │   ├── handlers/           # Claude Code stdin wrappers (call core/)
+│   │   │   ├── pre-tool-use/
+│   │   │   ├── subagent-stop/
+│   │   │   ├── session-start/
+│   │   │   ├── subagent-start/
+│   │   │   └── helpers/        # Already pure, stays here
+│   │   ├── parsers/
+│   │   │   ├── types.ts        # Add pi transcript types alongside Claude types
+│   │   │   ├── parse-transcript.ts        # Add pi adapter
+│   │   │   └── parse-files-modified.ts    # Add pi adapter
+│   │   ├── config.ts           # Make TASK_GRAPH_PATH configurable
+│   │   ├── types.ts
+│   │   ├── state-manager.ts
+│   │   ├── phase-init.ts
+│   │   ├── cli.ts              # Claude Code only
+│   │   └── utils/
+│   └── tests/
+│
+├── hooks/                      # CLAUDE CODE ONLY
+│   ├── hooks.json
+│   └── scripts/*.sh
+│
+└── pi/                         # PI ONLY
+    └── extension.ts            # Pi extension (calls engine/src/core/)
+```
+
+#### The `engine/src/core/` Extraction
+
+Each handler becomes a pure function that takes typed args and returns `HookResult`:
+
+```typescript
+// engine/src/core/validate-phase-order.ts
+import type { Phase, HookResult } from "../types";
+import { StateManager } from "../state-manager";
+import { VALID_TRANSITIONS, UTILITY_AGENTS } from "../config";
+import { stripNamespace } from "../utils/strip-namespace";
+
+export interface ValidatePhaseOrderInput {
+  toolName: string;       // "Task" (Claude) or "subagent" (pi)
+  agentType: string;      // bare agent name
+  prompt: string;         // task prompt
+}
+
+export function validatePhaseOrder(input: ValidatePhaseOrderInput): HookResult {
+  // All the current logic, but no JSON.parse(stdin)
+  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
+  const bareAgent = stripNamespace(input.agentType);
+  if (UTILITY_AGENTS.has(bareAgent)) return { kind: "allow" };
+  const targetPhase = detectPhase(bareAgent, input.prompt);
+  // ... rest of validation ...
+}
+```
+
+The Claude Code handler stays as a thin wrapper:
+```typescript
+// engine/src/handlers/pre-tool-use/validate-phase-order.ts
+import { validatePhaseOrder } from "../../core/validate-phase-order";
+const handler: HookHandler = async (stdin) => {
+  const input: PreToolUseInput = JSON.parse(stdin);
+  if (input.tool_name !== "Task") return { kind: "allow" };
+  return validatePhaseOrder({
+    toolName: input.tool_name,
+    agentType: (input.tool_input?.subagent_type as string) ?? "",
+    prompt: (input.tool_input?.prompt as string) ?? "",
+  });
+};
+```
+
+The pi extension calls the same core:
+```typescript
+// pi/extension.ts
+import { validatePhaseOrder } from "../engine/src/core/validate-phase-order";
+import { shouldBlockDirectEdit } from "../engine/src/core/block-direct-edits";
+import { guardStateFile } from "../engine/src/core/guard-state-file";
+// ... etc
+
+pi.on("tool_call", async (event, ctx) => {
+  // Subagent tool → phase validation
+  if (event.toolName === "subagent" && event.input.agent) {
+    const result = validatePhaseOrder({
+      toolName: "subagent",
+      agentType: event.input.agent,
+      prompt: event.input.task ?? "",
+    });
+    if (result.kind === "block") return { block: true, reason: result.message };
+  }
+
+  // Edit/Write → block direct edits
+  if (isToolCallEventType("edit", event) || isToolCallEventType("write", event)) {
+    const result = shouldBlockDirectEdit("Edit", ctx.sessionManager.getSessionId());
+    if (result.kind === "block") return { block: true, reason: result.message };
+  }
+
+  // Bash → guard state file
+  if (isToolCallEventType("bash", event)) {
+    const result = guardStateFile(event.input.command);
+    if (result.kind === "block") return { block: true, reason: result.message };
+  }
+});
+```
+
+#### Making `config.ts` Client-Agnostic
+
+The only path that differs is the state file location:
+
+```typescript
+// engine/src/config.ts
+function detectHarness(): "claude" | "pi" {
+  // Pi sets this, Claude Code doesn't
+  if (process.env.PI_CODING_AGENT_DIR) return "pi";
+  return "claude";
+}
+
+const TASK_GRAPH_RELATIVE = detectHarness() === "pi"
+  ? ".pi/state/active_task_graph.json"
+  : ".claude/state/active_task_graph.json";
+```
+
+Or simpler — just make it configurable:
+```typescript
+export const TASK_GRAPH_RELATIVE = process.env.LOOM_STATE_DIR
+  ?? ".claude/state/active_task_graph.json";
+```
+
+#### Making Transcript Parsers Client-Agnostic
+
+Add a format parameter:
+
+```typescript
+// engine/src/parsers/parse-transcript.ts
+export function parseTranscript(content: string, format: "claude" | "pi" = "claude"): string {
+  if (format === "pi") return parsePiTranscript(content);
+  return parseClaudeTranscript(content);  // existing logic
+}
+
+function parsePiTranscript(content: string): string {
+  const texts: string[] = [];
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type !== "message") continue;
+      const msg = entry.message;
+      if (msg.role === "assistant" || msg.role === "toolResult") {
+        for (const block of msg.content) {
+          if (block.type === "text") texts.push(block.text);
+        }
+      }
+    } catch {}
+  }
+  return texts.join("\n");
+}
+```
+
+#### Agent Frontmatter
+
+Claude Code agents have `color:` and `skills:` (auto-preload). Pi agents have `tools:`. Both share `name`, `description`, `model`.
+
+Simplest approach: **keep Claude Code frontmatter, handle the difference in pi's agent loader.** The pi subagent extension ignores unknown frontmatter fields, so `color:` and `skills:` are harmlessly ignored. For the `skills:` auto-preload, your pi extension can handle it:
+
+```typescript
+// In pi/extension.ts — custom agent loader that resolves skills: frontmatter
+function loadAgent(agentPath: string): AgentConfig {
+  const { frontmatter, body } = parseFrontmatter(readFileSync(agentPath, "utf-8"));
+  let systemPrompt = body;
+
+  // Resolve skills: frontmatter (Claude Code auto-preloads these)
+  if (frontmatter.skills) {
+    for (const skillName of frontmatter.skills) {
+      const skillPath = join(PACKAGE_ROOT, "skills", skillName, "SKILL.md");
+      if (existsSync(skillPath)) {
+        systemPrompt += "\n\n" + readFileSync(skillPath, "utf-8");
+      }
+    }
+  }
+
+  return { ...frontmatter, systemPrompt };
+}
+```
+
+#### Migration Phases (Revised for Dual-Client)
+
+**Phase 1 — Add pi support without breaking Claude Code:**
+1. Add `package.json` with `pi` manifest
+2. Create `pi/extension.ts` that calls existing handler logic directly
+3. Add `LOOM_STATE_DIR` env var support to `config.ts`
+4. Works immediately for skills, prompts, rules, references
+
+**Phase 2 — Extract `engine/src/core/` (pure functions):**
+1. Extract core logic from each handler into `core/` functions
+2. Thin Claude Code wrappers remain in `handlers/`
+3. Pi extension calls `core/` directly
+4. All existing tests still pass (test the core functions)
+
+**Phase 3 — Transcript parser adapter:**
+1. Add `format` parameter to parsers
+2. Add pi JSONL parsing alongside Claude Code parsing
+3. Test with pi subagent session output
+
+**Phase 4 — Agent skill preloading:**
+1. Custom agent loader in pi extension resolves `skills:` frontmatter
+2. Agent `.md` files stay identical for both clients

--- a/engine/src/config.ts
+++ b/engine/src/config.ts
@@ -114,8 +114,20 @@ export const VALID_TRANSITIONS: Record<Phase, Phase[]> = {
   "execute":         ["execute"],
 };
 
-/** Relative path within a repo root */
-const TASK_GRAPH_RELATIVE = ".claude/state/active_task_graph.json";
+/** Detect which harness is running */
+function detectHarness(): "claude" | "pi" {
+  if (process.env.PI_CODING_AGENT_DIR) return "pi";
+  return "claude";
+}
+
+/** Which harness is running */
+export const HARNESS = detectHarness();
+
+/** Relative path within a repo root — configurable via env */
+const TASK_GRAPH_RELATIVE = process.env.LOOM_STATE_PATH
+  ?? (HARNESS === "pi"
+    ? ".pi/state/active_task_graph.json"
+    : ".claude/state/active_task_graph.json");
 
 /** Find task graph by walking up from cwd to git root */
 function findTaskGraphPath(): string {
@@ -137,4 +149,4 @@ function findTaskGraphPath(): string {
 export const TASK_GRAPH_PATH = findTaskGraphPath();
 
 /** Subagent tracking directory */
-export const SUBAGENT_DIR = "/tmp/claude-subagents";
+export const SUBAGENT_DIR = process.env.LOOM_SUBAGENT_DIR ?? "/tmp/claude-subagents";

--- a/engine/src/core/block-direct-edits.ts
+++ b/engine/src/core/block-direct-edits.ts
@@ -1,0 +1,37 @@
+/**
+ * Core: Block Edit/Write from the MAIN agent during loom orchestration.
+ * Pure function — no stdin parsing.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import type { HookResult } from "../types";
+import { TASK_GRAPH_PATH, SUBAGENT_DIR } from "../config";
+
+const FILE_TOOLS = new Set(["Edit", "Write", "MultiEdit", "edit", "write"]);
+
+export function shouldBlockDirectEdit(toolName: string, sessionId: string): HookResult {
+  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
+  if (!FILE_TOOLS.has(toolName)) return { kind: "allow" };
+
+  // Allow if a subagent is active
+  const activeFile = `${SUBAGENT_DIR}/${sessionId}.active`;
+  try {
+    if (existsSync(activeFile) && statSync(activeFile).size > 0) {
+      return { kind: "allow" };
+    }
+  } catch {}
+
+  return {
+    kind: "block",
+    message: [
+      "BLOCKED: Direct edits not allowed during loom orchestration.",
+      "",
+      "Use the subagent tool with appropriate agent for implementation:",
+      "  - code-implementer-agent for production code",
+      "  - ts-test-agent for tests",
+      "  - frontend-agent for UI components",
+      "",
+      "This ensures proper phase sequencing and review gates.",
+    ].join("\n"),
+  };
+}

--- a/engine/src/core/guard-state-file.ts
+++ b/engine/src/core/guard-state-file.ts
@@ -1,0 +1,35 @@
+/**
+ * Core: Guard state files from direct modification via Bash.
+ * Pure function — no stdin parsing.
+ */
+
+import { existsSync } from "node:fs";
+import type { HookResult } from "../types";
+import { TASK_GRAPH_PATH, WHITELISTED_HELPERS, STATE_FILE_PATTERNS, WRITE_PATTERNS } from "../config";
+
+export function guardStateFile(command: string): HookResult {
+  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
+  if (!command) return { kind: "allow" };
+
+  // Allow whitelisted helper scripts
+  if (WHITELISTED_HELPERS.some((h) => command.includes(h))) {
+    return { kind: "allow" };
+  }
+
+  // Only inspect commands that reference state files
+  if (!STATE_FILE_PATTERNS.test(command)) return { kind: "allow" };
+
+  // Block write patterns
+  if (WRITE_PATTERNS.test(command)) {
+    return {
+      kind: "block",
+      message: [
+        "BLOCKED: Write to state file not allowed during loom workflow.",
+        "State is managed by hooks and helper scripts only.",
+        "Read access (jq, cat) is allowed.",
+      ].join("\n"),
+    };
+  }
+
+  return { kind: "allow" };
+}

--- a/engine/src/core/index.ts
+++ b/engine/src/core/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Core business logic — pure functions, no Claude Code stdin parsing.
+ * Both Claude Code handlers and pi extension import from here.
+ */
+
+export { shouldBlockDirectEdit } from "./block-direct-edits";
+export { guardStateFile } from "./guard-state-file";
+export { validatePhaseOrder, detectPhase, checkArtifacts } from "./validate-phase-order";
+export type { ValidatePhaseOrderInput, ArtifactState } from "./validate-phase-order";
+export { validateTaskExecution } from "./validate-task-execution";
+export type { ValidateTaskExecutionInput } from "./validate-task-execution";
+export { validateTemplateSubstitution } from "./validate-template-substitution";

--- a/engine/src/core/validate-phase-order.ts
+++ b/engine/src/core/validate-phase-order.ts
@@ -1,0 +1,170 @@
+/**
+ * Core: Enforce phase ordering during loom orchestration.
+ * Pure function — no stdin parsing.
+ *
+ * Re-exports detectPhase and checkArtifacts from the original handler
+ * for backwards compatibility.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { match } from "ts-pattern";
+import type { HookResult, Phase } from "../types";
+import {
+  TASK_GRAPH_PATH, PHASE_AGENT_MAP, IMPL_AGENTS, REVIEW_AGENTS,
+  UTILITY_AGENTS, VALID_TRANSITIONS, CLARIFY_THRESHOLD,
+} from "../config";
+import { StateManager } from "../state-manager";
+import { stripNamespace } from "../utils/strip-namespace";
+import { findFile } from "../utils/find-file";
+
+export interface ValidatePhaseOrderInput {
+  agentType: string;   // bare or namespaced agent name
+  prompt: string;      // task prompt
+}
+
+export function detectPhase(agent: string, prompt: string): Phase | "unknown" {
+  if (PHASE_AGENT_MAP[agent]) return PHASE_AGENT_MAP[agent];
+  if (IMPL_AGENTS.has(agent) || REVIEW_AGENTS.has(agent)) return "execute";
+
+  if (/brainstorm|explore.*intent|refine.*idea/i.test(prompt)) return "brainstorm";
+  if (/specify|specification|requirements|spec\.md/i.test(prompt)) return "specify";
+  if (/clarify|resolve.*markers|NEEDS CLARIFICATION/i.test(prompt)) return "clarify";
+  if (/architecture|design|plan\.md/i.test(prompt)) return "architecture";
+  if (/plan[\s\-_]alignment|gap[\s\-_]report/i.test(prompt)) return "plan-alignment";
+
+  return "unknown";
+}
+
+export interface ArtifactState {
+  skipped_phases: Phase[];
+  phase_artifacts: Partial<Record<Phase, string>>;
+  spec_file: string | null;
+  plan_file: string | null;
+  spec_dir?: string | null;
+}
+
+function checkPlanAlignmentGate(state: ArtifactState): string | null {
+  const plan = state.phase_artifacts.architecture ?? state.plan_file;
+  if (!plan || !existsSync(plan)) return "architecture (no plan.md found)";
+  if (!state.skipped_phases.includes("plan-alignment")) {
+    const specDir = state.spec_dir ?? ".claude/specs";
+    if (!findFile(specDir, "plan-alignment.md")) {
+      return "plan-alignment (no plan-alignment.md found)";
+    }
+  }
+  return null;
+}
+
+export function checkArtifacts(targetPhase: Phase, state: ArtifactState): string | null {
+  return match(targetPhase)
+    .with("specify", () => {
+      if (state.skipped_phases.includes("brainstorm")) return null;
+      const specDir = state.spec_dir ?? ".claude/specs";
+      if (!findFile(specDir, "brainstorm.md")) {
+        return `brainstorm (no brainstorm.md found in ${specDir})`;
+      }
+      return null;
+    })
+    .with("clarify", () => {
+      const spec = state.phase_artifacts.specify ?? state.spec_file;
+      if (!spec || !existsSync(spec)) return "specify (no spec.md found)";
+      return null;
+    })
+    .with("architecture", () => {
+      const spec = state.phase_artifacts.specify ?? state.spec_file;
+      if (!spec || !existsSync(spec)) return "specify (no spec.md found)";
+      if (!state.skipped_phases.includes("clarify")) {
+        try {
+          const content = readFileSync(spec, "utf-8");
+          const markers = (content.match(/NEEDS CLARIFICATION/g) ?? []).length;
+          if (markers > CLARIFY_THRESHOLD) return `clarify (${markers} markers > ${CLARIFY_THRESHOLD})`;
+        } catch (e) {
+          return `specify (spec.md unreadable: ${(e as Error).message})`;
+        }
+      }
+      return null;
+    })
+    .with("plan-alignment", () => {
+      const plan = state.phase_artifacts.architecture ?? state.plan_file;
+      if (!plan || !existsSync(plan)) return "architecture (no plan.md found)";
+      return null;
+    })
+    .with("decompose", () => checkPlanAlignmentGate(state))
+    .with("execute", () => checkPlanAlignmentGate(state))
+    .with("init", () => null)
+    .with("brainstorm", () => null)
+    .exhaustive();
+}
+
+export function validatePhaseOrder(input: ValidatePhaseOrderInput): HookResult {
+  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
+
+  const bareAgent = stripNamespace(input.agentType);
+
+  // Allow utility agents
+  if (UTILITY_AGENTS.has(bareAgent)) return { kind: "allow" };
+
+  const targetPhase = detectPhase(bareAgent, input.prompt);
+
+  if (targetPhase === "unknown") {
+    return {
+      kind: "block",
+      message: [
+        "BLOCKED: Unrecognized agent type during loom orchestration.",
+        "",
+        `Agent: ${input.agentType}`,
+        "",
+        "Use a recognized phase agent:",
+        "  brainstorm-agent, specify-agent, clarify-agent, architecture-agent,",
+        "  plan-alignment-agent, code-implementer-agent, ts-test-agent, frontend-agent, etc.",
+      ].join("\n"),
+    };
+  }
+
+  const mgr = StateManager.fromPath(TASK_GRAPH_PATH);
+  if (!mgr) return { kind: "allow" };
+  const state = mgr.load();
+  const currentPhase: Phase = state.current_phase ?? "init";
+
+  // Validate transition
+  const allowed = VALID_TRANSITIONS[currentPhase] ?? [];
+  if (!allowed.includes(targetPhase)) {
+    return {
+      kind: "block",
+      message: [
+        `BLOCKED: Invalid phase transition: ${currentPhase} → ${targetPhase}`,
+        "",
+        "Expected flow: brainstorm → specify → clarify → architecture → plan-alignment → decompose → execute",
+        `Current phase: ${currentPhase}`,
+        "",
+        match(currentPhase)
+          .with("init", () => "Next: Run brainstorm-agent (or --skip-brainstorm)")
+          .with("brainstorm", () => "Next: Run specify-agent")
+          .with("specify", () => "Next: Run clarify-agent or architecture-agent")
+          .with("clarify", () => "Next: Run architecture-agent")
+          .with("architecture", () => "Next: Run plan-alignment-agent (or --skip-plan-alignment)")
+          .with("plan-alignment", () => "Next: Run plan-alignment-agent, or loop back with architecture-agent")
+          .with("decompose", () => "")
+          .with("execute", () => "")
+          .exhaustive(),
+      ].join("\n"),
+    };
+  }
+
+  // Check artifact requirements
+  const missing = checkArtifacts(targetPhase, state);
+  if (missing) {
+    return {
+      kind: "block",
+      message: [
+        `BLOCKED: Missing prerequisite for ${targetPhase} phase`,
+        "",
+        `Required: ${missing}`,
+        "",
+        "Complete the prerequisite phase first, or use --skip-X flag.",
+      ].join("\n"),
+    };
+  }
+
+  return { kind: "allow" };
+}

--- a/engine/src/core/validate-task-execution.ts
+++ b/engine/src/core/validate-task-execution.ts
@@ -1,0 +1,96 @@
+/**
+ * Core: Validate wave order, dependencies, and review gates before task execution.
+ * Pure function — no stdin parsing.
+ */
+
+import { existsSync } from "node:fs";
+import type { HookResult } from "../types";
+import { TASK_GRAPH_PATH } from "../config";
+import { extractTaskId } from "../utils/extract-task-id";
+import { StateManager } from "../state-manager";
+import * as git from "../utils/git";
+
+export interface ValidateTaskExecutionInput {
+  prompt: string;
+  description: string;
+}
+
+export async function validateTaskExecution(input: ValidateTaskExecutionInput): Promise<HookResult> {
+  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
+
+  const taskId = extractTaskId(input.prompt) ?? extractTaskId(input.description);
+  if (!taskId) return { kind: "allow" };
+
+  const mgr = StateManager.fromPath(TASK_GRAPH_PATH);
+  if (!mgr) return { kind: "allow" };
+
+  const state = mgr.load();
+  const task = state.tasks.find((t) => t.id === taskId);
+  if (!task) return { kind: "allow" };
+
+  const currentWave = state.current_wave ?? 1;
+
+  // Check 1: Wave order
+  if (task.wave > currentWave) {
+    return {
+      kind: "block",
+      message: `BLOCKED: Cannot execute ${taskId} (wave ${task.wave}) - current wave is ${currentWave}\nComplete all wave ${currentWave} tasks first.`,
+    };
+  }
+
+  // Check 2: Dependencies complete
+  for (const dep of task.depends_on) {
+    const depTask = state.tasks.find((t) => t.id === dep);
+    if (!depTask) {
+      return {
+        kind: "block",
+        message: `BLOCKED: Cannot execute ${taskId} - dependency ${dep} not found in task graph`,
+      };
+    }
+    if (depTask.status !== "completed") {
+      return {
+        kind: "block",
+        message: `BLOCKED: Cannot execute ${taskId} - dependency ${dep} not complete (status: ${depTask.status})`,
+      };
+    }
+  }
+
+  // Check 3: Previous wave review gate (only for wave > 1)
+  if (task.wave === currentWave && currentWave > 1) {
+    const prevWave = String(currentWave - 1);
+    const gate = state.wave_gates[prevWave];
+
+    if (gate && !gate.reviews_complete) {
+      const lines = [`BLOCKED: Wave ${prevWave} review gate not passed.`, ""];
+      if (gate.blocked) {
+        lines.push(`Wave ${prevWave} is BLOCKED due to:`);
+        if (gate.tests_passed === false) lines.push("  - Integration tests failed");
+        const critCount = state.tasks
+          .filter((t) => t.wave === currentWave - 1)
+          .reduce((sum, t) => sum + (t.critical_findings?.length ?? 0), 0);
+        if (critCount > 0) lines.push(`  - ${critCount} critical review findings`);
+      } else {
+        lines.push(`Wave ${prevWave} gates not yet run.`);
+      }
+      lines.push("", "Run: /wave-gate");
+
+      return { kind: "block", message: lines.join("\n") };
+    }
+  }
+
+  // Store baseline SHA + add to executing_tasks atomically
+  if (taskId && git.isGitRepo()) {
+    const sha = git.headSha();
+    if (sha) {
+      await mgr.update((s) => ({
+        ...s,
+        executing_tasks: [...new Set([...(s.executing_tasks ?? []), taskId])],
+        tasks: s.tasks.map((t) =>
+          t.id === taskId ? { ...t, start_sha: sha } : t
+        ),
+      }));
+    }
+  }
+
+  return { kind: "allow" };
+}

--- a/engine/src/core/validate-template-substitution.ts
+++ b/engine/src/core/validate-template-substitution.ts
@@ -1,0 +1,36 @@
+/**
+ * Core: Validate that task prompts have no unsubstituted template variables.
+ * Pure function — no stdin parsing.
+ */
+
+import { existsSync } from "node:fs";
+import type { HookResult } from "../types";
+import { TASK_GRAPH_PATH } from "../config";
+
+const FALSE_POSITIVES = new Set(["{type}", "{id}", "{name}"]);
+
+export function validateTemplateSubstitution(prompt: string): HookResult {
+  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
+  if (!prompt) return { kind: "allow" };
+
+  // Remove shell ${var} expansions to avoid false positives
+  const cleaned = prompt.replace(/\$\{[^}]*\}/g, "");
+
+  const matches = cleaned.match(/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g) ?? [];
+  const realIssues = matches.filter((v) => !FALSE_POSITIVES.has(v));
+
+  if (realIssues.length === 0) return { kind: "allow" };
+
+  return {
+    kind: "block",
+    message: [
+      "BLOCKED: Task prompt contains unsubstituted template variables:",
+      `  ${realIssues.join(" ")}`,
+      "",
+      "These should have been substituted before spawning:",
+      ...realIssues.map((v) => `  - ${v}`),
+      "",
+      "Check the /loom skill template substitution logic.",
+    ].join("\n"),
+  };
+}

--- a/engine/src/handlers/pre-tool-use/block-direct-edits.ts
+++ b/engine/src/handlers/pre-tool-use/block-direct-edits.ts
@@ -1,42 +1,16 @@
 /**
  * Block Edit/Write from the MAIN agent during loom orchestration.
  * Subagent Edit/Write is allowed — detected via /tmp/claude-subagents/ flag.
+ *
+ * Claude Code wrapper — delegates to core/.
  */
 
-import { existsSync, statSync } from "node:fs";
 import type { HookHandler, PreToolUseInput } from "../../types";
-import { TASK_GRAPH_PATH, SUBAGENT_DIR } from "../../config";
-
-const FILE_TOOLS = new Set(["Edit", "Write", "MultiEdit"]);
+import { shouldBlockDirectEdit } from "../../core/block-direct-edits";
 
 const handler: HookHandler = async (stdin) => {
-  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
-
   const input: PreToolUseInput = JSON.parse(stdin);
-
-  if (!FILE_TOOLS.has(input.tool_name)) return { kind: "allow" };
-
-  // Allow if a subagent is active
-  const activeFile = `${SUBAGENT_DIR}/${input.session_id}.active`;
-  try {
-    if (existsSync(activeFile) && statSync(activeFile).size > 0) {
-      return { kind: "allow" };
-    }
-  } catch {}
-
-  return {
-    kind: "block",
-    message: [
-      "BLOCKED: Direct edits not allowed during loom orchestration.",
-      "",
-      "Use Task tool with appropriate agent for implementation:",
-      "  - code-implementer-agent for production code",
-      "  - ts-test-agent for tests",
-      "  - frontend-agent for UI components",
-      "",
-      "This ensures proper phase sequencing and review gates.",
-    ].join("\n"),
-  };
+  return shouldBlockDirectEdit(input.tool_name, input.session_id);
 };
 
 export default handler;

--- a/engine/src/handlers/pre-tool-use/guard-state-file.ts
+++ b/engine/src/handlers/pre-tool-use/guard-state-file.ts
@@ -1,40 +1,16 @@
 /**
  * Guard state files from direct modification via Bash tool.
- * Allows reads (jq, cat) but blocks writes (>, mv, cp, tee, sed -i, etc.)
+ *
+ * Claude Code wrapper — delegates to core/.
  */
 
-import { existsSync } from "node:fs";
 import type { HookHandler, PreToolUseInput } from "../../types";
-import { TASK_GRAPH_PATH, WHITELISTED_HELPERS, STATE_FILE_PATTERNS, WRITE_PATTERNS } from "../../config";
+import { guardStateFile } from "../../core/guard-state-file";
 
 const handler: HookHandler = async (stdin) => {
-  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
-
   const input: PreToolUseInput = JSON.parse(stdin);
   const command = (input.tool_input?.command as string) ?? "";
-  if (!command) return { kind: "allow" };
-
-  // Allow whitelisted helper scripts (old .sh and new CLI format)
-  if (WHITELISTED_HELPERS.some((h) => command.includes(h))) {
-    return { kind: "allow" };
-  }
-
-  // Only inspect commands that reference state files
-  if (!STATE_FILE_PATTERNS.test(command)) return { kind: "allow" };
-
-  // Block write patterns
-  if (WRITE_PATTERNS.test(command)) {
-    return {
-      kind: "block",
-      message: [
-        "BLOCKED: Write to state file not allowed during loom workflow.",
-        "State is managed by SubagentStop hooks and helper scripts only.",
-        "Read access (jq, cat) is allowed.",
-      ].join("\n"),
-    };
-  }
-
-  return { kind: "allow" };
+  return guardStateFile(command);
 };
 
 export default handler;

--- a/engine/src/handlers/pre-tool-use/validate-phase-order.ts
+++ b/engine/src/handlers/pre-tool-use/validate-phase-order.ts
@@ -1,98 +1,14 @@
 /**
  * Enforce phase ordering: brainstorm → specify → clarify → architecture → plan-alignment → decompose → execute
- * Blocks agent spawns if prerequisite phases not complete.
+ *
+ * Claude Code wrapper — delegates to core/.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { match } from "ts-pattern";
-import type { HookHandler, PreToolUseInput, Phase } from "../../types";
-import {
-  TASK_GRAPH_PATH, PHASE_AGENT_MAP, IMPL_AGENTS, REVIEW_AGENTS,
-  UTILITY_AGENTS, VALID_TRANSITIONS, CLARIFY_THRESHOLD,
-} from "../../config";
-import { StateManager } from "../../state-manager";
+import type { HookHandler, PreToolUseInput } from "../../types";
+import { validatePhaseOrder } from "../../core/validate-phase-order";
 import { stripNamespace } from "../../utils/strip-namespace";
-import { findFile } from "../../utils/find-file";
-
-export function detectPhase(agent: string, prompt: string): Phase | "unknown" {
-  if (PHASE_AGENT_MAP[agent]) return PHASE_AGENT_MAP[agent];
-  if (IMPL_AGENTS.has(agent) || REVIEW_AGENTS.has(agent)) return "execute";
-
-  // Fallback: check prompt for phase indicators
-  if (/brainstorm|explore.*intent|refine.*idea/i.test(prompt)) return "brainstorm";
-  if (/specify|specification|requirements|spec\.md/i.test(prompt)) return "specify";
-  if (/clarify|resolve.*markers|NEEDS CLARIFICATION/i.test(prompt)) return "clarify";
-  if (/architecture|design|plan\.md/i.test(prompt)) return "architecture";
-  if (/plan[\s\-_]alignment|gap[\s\-_]report/i.test(prompt)) return "plan-alignment";
-
-  return "unknown";
-}
-
-export interface ArtifactState {
-  skipped_phases: Phase[];
-  phase_artifacts: Partial<Record<Phase, string>>;
-  spec_file: string | null;
-  plan_file: string | null;
-  spec_dir?: string | null;
-}
-
-/** Check plan-alignment gate: plan.md exists + plan-alignment.md exists (unless skipped) */
-function checkPlanAlignmentGate(state: ArtifactState): string | null {
-  const plan = state.phase_artifacts.architecture ?? state.plan_file;
-  if (!plan || !existsSync(plan)) return "architecture (no plan.md found)";
-  if (!state.skipped_phases.includes("plan-alignment")) {
-    const specDir = state.spec_dir ?? ".claude/specs";
-    if (!findFile(specDir, "plan-alignment.md")) {
-      return "plan-alignment (no plan-alignment.md found)";
-    }
-  }
-  return null;
-}
-
-export function checkArtifacts(targetPhase: Phase, state: ArtifactState): string | null {
-  return match(targetPhase)
-    .with("specify", () => {
-      if (state.skipped_phases.includes("brainstorm")) return null;
-      const specDir = state.spec_dir ?? ".claude/specs";
-      if (!findFile(specDir, "brainstorm.md")) {
-        return `brainstorm (no brainstorm.md found in ${specDir})`;
-      }
-      return null;
-    })
-    .with("clarify", () => {
-      const spec = state.phase_artifacts.specify ?? state.spec_file;
-      if (!spec || !existsSync(spec)) return "specify (no spec.md found)";
-      return null;
-    })
-    .with("architecture", () => {
-      const spec = state.phase_artifacts.specify ?? state.spec_file;
-      if (!spec || !existsSync(spec)) return "specify (no spec.md found)";
-      if (!state.skipped_phases.includes("clarify")) {
-        try {
-          const content = readFileSync(spec, "utf-8");
-          const markers = (content.match(/NEEDS CLARIFICATION/g) ?? []).length;
-          if (markers > CLARIFY_THRESHOLD) return `clarify (${markers} markers > ${CLARIFY_THRESHOLD})`;
-        } catch (e) {
-          return `specify (spec.md unreadable: ${(e as Error).message})`;
-        }
-      }
-      return null;
-    })
-    .with("plan-alignment", () => {
-      const plan = state.phase_artifacts.architecture ?? state.plan_file;
-      if (!plan || !existsSync(plan)) return "architecture (no plan.md found)";
-      return null;
-    })
-    .with("decompose", () => checkPlanAlignmentGate(state))
-    .with("execute", () => checkPlanAlignmentGate(state))
-    .with("init", () => null)
-    .with("brainstorm", () => null)
-    .exhaustive();
-}
 
 const handler: HookHandler = async (stdin) => {
-  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
-
   let input: PreToolUseInput;
   try {
     input = JSON.parse(stdin);
@@ -102,76 +18,14 @@ const handler: HookHandler = async (stdin) => {
   }
   if (input.tool_name !== "Task") return { kind: "allow" };
 
-  const prompt = (input.tool_input?.prompt as string) ?? "";
-  const subagentType = (input.tool_input?.subagent_type as string) ?? "";
-  const bareAgent = stripNamespace(subagentType);
-
-  // Allow utility agents
-  if (UTILITY_AGENTS.has(bareAgent)) return { kind: "allow" };
-
-  const targetPhase = detectPhase(bareAgent, prompt);
-
-  if (targetPhase === "unknown") {
-    return {
-      kind: "block",
-      message: [
-        "BLOCKED: Unrecognized agent type during loom orchestration.",
-        "",
-        `Agent: ${subagentType}`,
-        "",
-        "Use a recognized phase agent:",
-        "  brainstorm-agent, specify-agent, clarify-agent, architecture-agent,",
-        "  plan-alignment-agent, code-implementer-agent, ts-test-agent, frontend-agent, etc.",
-      ].join("\n"),
-    };
-  }
-
-  const mgr = StateManager.fromPath(TASK_GRAPH_PATH);
-  if (!mgr) return { kind: "allow" };
-  const state = mgr.load();
-  const currentPhase: Phase = state.current_phase ?? "init";
-
-  // Validate transition
-  const allowed = VALID_TRANSITIONS[currentPhase] ?? [];
-  if (!allowed.includes(targetPhase)) {
-    return {
-      kind: "block",
-      message: [
-        `BLOCKED: Invalid phase transition: ${currentPhase} → ${targetPhase}`,
-        "",
-        "Expected flow: brainstorm → specify → clarify → architecture → plan-alignment → decompose → execute",
-        `Current phase: ${currentPhase}`,
-        "",
-        match(currentPhase)
-          .with("init", () => "Next: Run brainstorm-agent (or --skip-brainstorm)")
-          .with("brainstorm", () => "Next: Run specify-agent")
-          .with("specify", () => "Next: Run clarify-agent or architecture-agent")
-          .with("clarify", () => "Next: Run architecture-agent")
-          .with("architecture", () => "Next: Run plan-alignment-agent (or --skip-plan-alignment)")
-          .with("plan-alignment", () => "Next: Run plan-alignment-agent, or loop back with architecture-agent")
-          .with("decompose", () => "")
-          .with("execute", () => "")
-          .exhaustive(),
-      ].join("\n"),
-    };
-  }
-
-  // Check artifact requirements
-  const missing = checkArtifacts(targetPhase, state);
-  if (missing) {
-    return {
-      kind: "block",
-      message: [
-        `BLOCKED: Missing prerequisite for ${targetPhase} phase`,
-        "",
-        `Required: ${missing}`,
-        "",
-        "Complete the prerequisite phase first, or use --skip-X flag.",
-      ].join("\n"),
-    };
-  }
-
-  return { kind: "allow" };
+  return validatePhaseOrder({
+    agentType: stripNamespace((input.tool_input?.subagent_type as string) ?? ""),
+    prompt: (input.tool_input?.prompt as string) ?? "",
+  });
 };
 
 export default handler;
+
+// Re-export for tests that import from handler path
+export { detectPhase, checkArtifacts } from "../../core/validate-phase-order";
+export type { ArtifactState } from "../../core/validate-phase-order";

--- a/engine/src/handlers/pre-tool-use/validate-task-execution.ts
+++ b/engine/src/handlers/pre-tool-use/validate-task-execution.ts
@@ -1,100 +1,20 @@
 /**
  * Validate wave order, dependencies, and review gates before task execution.
- * Also stores baseline SHA for per-task new-test detection.
+ *
+ * Claude Code wrapper — delegates to core/.
  */
 
-import { existsSync } from "node:fs";
 import type { HookHandler, PreToolUseInput } from "../../types";
-import { TASK_GRAPH_PATH } from "../../config";
-import { extractTaskId } from "../../utils/extract-task-id";
-import { StateManager } from "../../state-manager";
-import * as git from "../../utils/git";
+import { validateTaskExecution } from "../../core/validate-task-execution";
 
 const handler: HookHandler = async (stdin) => {
-  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
-
   const input: PreToolUseInput = JSON.parse(stdin);
   if (input.tool_name !== "Task") return { kind: "allow" };
 
-  const prompt = (input.tool_input?.prompt as string) ?? "";
-  const description = (input.tool_input?.description as string) ?? "";
-
-  // Extract task ID from prompt or description
-  const taskId = extractTaskId(prompt) ?? extractTaskId(description);
-  if (!taskId) return { kind: "allow" }; // Not a planned task
-
-  const mgr = StateManager.fromPath(TASK_GRAPH_PATH);
-  if (!mgr) return { kind: "allow" };
-
-  const state = mgr.load();
-  const task = state.tasks.find((t) => t.id === taskId);
-  if (!task) return { kind: "allow" }; // Task not in graph
-
-  const currentWave = state.current_wave ?? 1;
-
-  // Check 1: Wave order
-  if (task.wave > currentWave) {
-    return {
-      kind: "block",
-      message: `BLOCKED: Cannot execute ${taskId} (wave ${task.wave}) - current wave is ${currentWave}\nComplete all wave ${currentWave} tasks first.`,
-    };
-  }
-
-  // Check 2: Dependencies complete
-  for (const dep of task.depends_on) {
-    const depTask = state.tasks.find((t) => t.id === dep);
-    if (!depTask) {
-      return {
-        kind: "block",
-        message: `BLOCKED: Cannot execute ${taskId} - dependency ${dep} not found in task graph`,
-      };
-    }
-    if (depTask.status !== "completed") {
-      return {
-        kind: "block",
-        message: `BLOCKED: Cannot execute ${taskId} - dependency ${dep} not complete (status: ${depTask.status})`,
-      };
-    }
-  }
-
-  // Check 3: Previous wave review gate (only for wave > 1)
-  if (task.wave === currentWave && currentWave > 1) {
-    const prevWave = String(currentWave - 1);
-    const gate = state.wave_gates[prevWave];
-
-    if (gate && !gate.reviews_complete) {
-      const lines = [`BLOCKED: Wave ${prevWave} review gate not passed.`, ""];
-      if (gate.blocked) {
-        lines.push(`Wave ${prevWave} is BLOCKED due to:`);
-        if (gate.tests_passed === false) lines.push("  - Integration tests failed");
-        const critCount = state.tasks
-          .filter((t) => t.wave === currentWave - 1)
-          .reduce((sum, t) => sum + (t.critical_findings?.length ?? 0), 0);
-        if (critCount > 0) lines.push(`  - ${critCount} critical review findings`);
-      } else {
-        lines.push(`Wave ${prevWave} gates not yet run.`);
-      }
-      lines.push("", "Run: /wave-gate");
-
-      return { kind: "block", message: lines.join("\n") };
-    }
-  }
-
-  // Store baseline SHA + add to executing_tasks atomically
-  if (taskId && git.isGitRepo()) {
-    const sha = git.headSha();
-    if (sha) {
-      await mgr.update((s) => ({
-        ...s,
-        executing_tasks: [...new Set([...(s.executing_tasks ?? []), taskId])],
-        tasks: s.tasks.map((t) =>
-          t.id === taskId ? { ...t, start_sha: sha } : t
-        ),
-      }));
-    }
-  }
-
-  return { kind: "allow" };
+  return validateTaskExecution({
+    prompt: (input.tool_input?.prompt as string) ?? "",
+    description: (input.tool_input?.description as string) ?? "",
+  });
 };
 
 export default handler;

--- a/engine/src/handlers/pre-tool-use/validate-template-substitution.ts
+++ b/engine/src/handlers/pre-tool-use/validate-template-substitution.ts
@@ -1,45 +1,18 @@
 /**
  * Validate that Task tool prompts have no unsubstituted template variables.
- * Blocks Task spawns containing {variable} patterns.
+ *
+ * Claude Code wrapper — delegates to core/.
  */
 
-import { existsSync } from "node:fs";
 import type { HookHandler, PreToolUseInput } from "../../types";
-import { TASK_GRAPH_PATH } from "../../config";
-
-// Common false positives to skip
-const FALSE_POSITIVES = new Set(["{type}", "{id}", "{name}"]);
+import { validateTemplateSubstitution } from "../../core/validate-template-substitution";
 
 const handler: HookHandler = async (stdin) => {
-  if (!existsSync(TASK_GRAPH_PATH)) return { kind: "allow" };
-
   const input: PreToolUseInput = JSON.parse(stdin);
   if (input.tool_name !== "Task") return { kind: "allow" };
 
   const prompt = (input.tool_input?.prompt as string) ?? "";
-  if (!prompt) return { kind: "allow" };
-
-  // Remove shell ${var} expansions to avoid false positives
-  const cleaned = prompt.replace(/\$\{[^}]*\}/g, "");
-
-  // Find {word} patterns
-  const matches = cleaned.match(/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g) ?? [];
-  const realIssues = matches.filter((v) => !FALSE_POSITIVES.has(v));
-
-  if (realIssues.length === 0) return { kind: "allow" };
-
-  return {
-    kind: "block",
-    message: [
-      "BLOCKED: Task prompt contains unsubstituted template variables:",
-      `  ${realIssues.join(" ")}`,
-      "",
-      "These should have been substituted before spawning:",
-      ...realIssues.map((v) => `  - ${v}`),
-      "",
-      "Check the /loom skill template substitution logic.",
-    ].join("\n"),
-  };
+  return validateTemplateSubstitution(prompt);
 };
 
 export default handler;

--- a/engine/src/parsers/parse-files-modified.ts
+++ b/engine/src/parsers/parse-files-modified.ts
@@ -1,12 +1,15 @@
 /**
- * Extract Write/Edit file paths from a Claude Code JSONL transcript
- * Returns deduplicated, sorted list of absolute file paths modified by agent
+ * Extract Write/Edit file paths from a JSONL transcript.
+ * Supports both Claude Code and pi formats (auto-detected or explicit).
  */
 
-import { parseJsonl, getContentBlocks } from "./types";
+import { parseJsonl, parsePiJsonl, getContentBlocks, detectFormat, type TranscriptFormat } from "./types";
 import { FILE_MODIFYING_TOOLS } from "../config";
 
-export function parseFilesModified(content: string): string[] {
+/** Pi tool names that modify files */
+const PI_FILE_TOOLS = new Set(["write", "edit"]);
+
+function parseClaudeFilesModified(content: string): string[] {
   const files = new Set<string>();
 
   for (const line of parseJsonl(content)) {
@@ -26,4 +29,35 @@ export function parseFilesModified(content: string): string[] {
   }
 
   return [...files].sort();
+}
+
+function parsePiFilesModified(content: string): string[] {
+  const files = new Set<string>();
+
+  for (const entry of parsePiJsonl(content)) {
+    if (entry.type !== "message") continue;
+    const msg = entry.message;
+    if (!msg || msg.role !== "assistant") continue;
+    if (!Array.isArray(msg.content)) continue;
+
+    for (const block of msg.content) {
+      // Pi embeds tool calls in assistant content as { type: "toolCall", name, arguments }
+      if (block.type !== "toolCall") continue;
+      if (!block.name || !PI_FILE_TOOLS.has(block.name)) continue;
+
+      const args = block.arguments as Record<string, unknown> | undefined;
+      const filePath = args?.path ?? args?.file_path;
+
+      if (typeof filePath === "string") {
+        files.add(filePath);
+      }
+    }
+  }
+
+  return [...files].sort();
+}
+
+export function parseFilesModified(content: string, format?: TranscriptFormat): string[] {
+  const fmt = format ?? detectFormat(content);
+  return fmt === "pi" ? parsePiFilesModified(content) : parseClaudeFilesModified(content);
 }

--- a/engine/src/parsers/parse-transcript.ts
+++ b/engine/src/parsers/parse-transcript.ts
@@ -1,9 +1,9 @@
 /**
- * Extract plain text from a Claude Code JSONL transcript
- * Parses assistant messages, tool results, and nested content blocks
+ * Extract plain text from a JSONL transcript.
+ * Supports both Claude Code and pi formats (auto-detected or explicit).
  */
 
-import { parseJsonl, getContentBlocks, type ContentBlock } from "./types";
+import { parseJsonl, parsePiJsonl, getContentBlocks, detectFormat, type ContentBlock, type TranscriptFormat } from "./types";
 
 function extractText(block: ContentBlock): string[] {
   const texts: string[] = [];
@@ -26,7 +26,7 @@ function extractText(block: ContentBlock): string[] {
   return texts;
 }
 
-export function parseTranscript(content: string): string {
+function parseClaudeTranscript(content: string): string {
   const texts: string[] = [];
 
   for (const line of parseJsonl(content)) {
@@ -43,4 +43,34 @@ export function parseTranscript(content: string): string {
   }
 
   return texts.join("\n");
+}
+
+function parsePiTranscript(content: string): string {
+  const texts: string[] = [];
+
+  for (const entry of parsePiJsonl(content)) {
+    if (entry.type !== "message") continue;
+    const msg = entry.message;
+    if (!msg) continue;
+
+    if (typeof msg.content === "string") {
+      texts.push(msg.content);
+      continue;
+    }
+
+    if (Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (block.type === "text" && block.text) {
+          texts.push(block.text);
+        }
+      }
+    }
+  }
+
+  return texts.join("\n");
+}
+
+export function parseTranscript(content: string, format?: TranscriptFormat): string {
+  const fmt = format ?? detectFormat(content);
+  return fmt === "pi" ? parsePiTranscript(content) : parseClaudeTranscript(content);
 }

--- a/engine/src/parsers/types.ts
+++ b/engine/src/parsers/types.ts
@@ -1,6 +1,11 @@
 /**
- * Shared types for Claude Code JSONL transcript parsing
+ * Shared types for JSONL transcript parsing.
+ * Supports both Claude Code and pi formats.
  */
+
+export type TranscriptFormat = "claude" | "pi";
+
+// --- Claude Code types ---
 
 export interface TranscriptLine {
   message?: {
@@ -33,7 +38,32 @@ export interface ToolResultBlock extends ContentBlock {
   content: string | ContentBlock[];
 }
 
-/** Read and parse JSONL file line by line */
+// --- Pi types ---
+
+export interface PiEntry {
+  type: string;
+  id?: string;
+  parentId?: string | null;
+  message?: {
+    role: string;
+    content: PiContentBlock[] | string;
+    toolCallId?: string;
+    toolName?: string;
+    isError?: boolean;
+  };
+}
+
+export interface PiContentBlock {
+  type: string;
+  text?: string;
+  name?: string;
+  id?: string;
+  arguments?: Record<string, unknown>;
+}
+
+// --- Shared parsers ---
+
+/** Read and parse JSONL file line by line (Claude Code format) */
 export function* parseJsonl(content: string): Generator<TranscriptLine> {
   for (const line of content.split("\n")) {
     if (!line.trim()) continue;
@@ -45,10 +75,33 @@ export function* parseJsonl(content: string): Generator<TranscriptLine> {
   }
 }
 
-/** Extract content blocks from a transcript line */
+/** Read and parse JSONL file line by line (pi format) */
+export function* parsePiJsonl(content: string): Generator<PiEntry> {
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      yield JSON.parse(line) as PiEntry;
+    } catch {
+      // Skip invalid JSON lines
+    }
+  }
+}
+
+/** Extract content blocks from a transcript line (Claude Code) */
 export function getContentBlocks(line: TranscriptLine): ContentBlock[] {
   const content = line.message?.content;
   if (!content) return [];
   if (typeof content === "string") return [];
   return content;
+}
+
+/** Detect transcript format from content */
+export function detectFormat(content: string): TranscriptFormat {
+  // Pi sessions start with {"type":"session","version":...}
+  const firstLine = content.split("\n")[0] ?? "";
+  try {
+    const parsed = JSON.parse(firstLine);
+    if (parsed.type === "session" && parsed.version !== undefined) return "pi";
+  } catch {}
+  return "claude";
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@peterstorm/loom",
+  "version": "1.0.1",
+  "description": "Loom orchestration system - multi-phase task decomposition with wave-based parallel execution",
+  "keywords": ["pi-package"],
+  "type": "module",
+  "author": { "name": "peterstorm" },
+  "pi": {
+    "extensions": ["./pi"],
+    "skills": ["./skills", "./commands/nextjs-frontend-design", "./commands/vercel-react-best-practices"],
+    "prompts": ["./commands"]
+  },
+  "dependencies": {
+    "ts-pattern": "^5.9.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "typebox": "*"
+  }
+}

--- a/pi/extension.ts
+++ b/pi/extension.ts
@@ -1,0 +1,419 @@
+/**
+ * Loom Pi Extension
+ *
+ * Bridges loom's orchestration engine to pi's extension API.
+ * Delegates to engine/src/core/ for all business logic.
+ */
+
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, mkdirSync, appendFileSync, writeFileSync } from "node:fs";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isToolCallEventType, parseFrontmatter } from "@earendil-works/pi-coding-agent";
+
+// Engine core — pure functions, no Claude Code dependency
+import { shouldBlockDirectEdit } from "../engine/src/core/block-direct-edits";
+import { guardStateFile } from "../engine/src/core/guard-state-file";
+import { validatePhaseOrder } from "../engine/src/core/validate-phase-order";
+import { validateTaskExecution } from "../engine/src/core/validate-task-execution";
+import { validateTemplateSubstitution } from "../engine/src/core/validate-template-substitution";
+
+// Engine parsers (format-aware)
+import { parseTranscript } from "../engine/src/parsers/parse-transcript";
+import { parseFilesModified } from "../engine/src/parsers/parse-files-modified";
+import { parseBashTestOutput } from "../engine/src/parsers/parse-bash-test-output";
+import { parsePhaseArtifacts } from "../engine/src/parsers/parse-phase-artifacts";
+
+// Engine SubagentStop logic (pure functions already exported)
+import { extractTestEvidence, analyzeNewTests } from "../engine/src/handlers/subagent-stop/update-task-status";
+import { resolveTransition } from "../engine/src/handlers/subagent-stop/advance-phase";
+import {
+  isReviewAgent, parseMachineSummary, parseLegacyFindings,
+  reconcileFindings, mergeFindings, buildEvidenceFailureMessage,
+} from "../engine/src/handlers/subagent-stop/store-reviewer-findings";
+import { parseSpecCheckOutput } from "../engine/src/handlers/subagent-stop/store-spec-check-findings";
+import type { ReviewStatus, SpecCheck, Phase } from "../engine/src/types";
+
+import { TASK_GRAPH_PATH, SUBAGENT_DIR, HARNESS, PHASE_AGENT_MAP, IMPL_AGENTS, PHASE_ORDER } from "../engine/src/config";
+import { StateManager } from "../engine/src/state-manager";
+import { buildContextOutput } from "../engine/src/handlers/session-start/resume-after-clear";
+import { stripNamespace } from "../engine/src/utils/strip-namespace";
+import { extractTaskId } from "../engine/src/utils/extract-task-id";
+import * as git from "../engine/src/utils/git";
+
+const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const AGENTS_DIR = join(PACKAGE_ROOT, "agents");
+const SKILLS_DIR = join(PACKAGE_ROOT, "skills");
+
+export default function (pi: ExtensionAPI) {
+  // ─── Resource Discovery ───────────────────────────────────────────────
+  // Contribute skills from this package that aren't in the pi manifest's
+  // auto-discovery (the manifest covers skills/ and commands/ already,
+  // but we also register agents dir for the subagent tool).
+
+  pi.on("resources_discover", () => ({
+    skillPaths: [
+      join(PACKAGE_ROOT, "skills"),
+    ],
+    promptPaths: [
+      join(PACKAGE_ROOT, "commands"),
+    ],
+  }));
+
+  // ─── PreToolUse Guards (tool_call event) ──────────────────────────────
+
+  pi.on("tool_call", async (event, ctx) => {
+    const sessionId = ctx.sessionManager.getSessionId() ?? "unknown";
+
+    // Block direct edits during orchestration
+    if (isToolCallEventType("edit", event) || isToolCallEventType("write", event)) {
+      const result = shouldBlockDirectEdit(event.toolName, sessionId);
+      if (result.kind === "block") {
+        return { block: true, reason: result.message };
+      }
+    }
+
+    // Guard state file from bash writes
+    if (isToolCallEventType("bash", event)) {
+      const result = guardStateFile(event.input.command ?? "");
+      if (result.kind === "block") {
+        return { block: true, reason: result.message };
+      }
+    }
+
+    // Subagent tool → phase and task validation
+    if (event.toolName === "subagent") {
+      const agent = (event.input as Record<string, unknown>).agent as string | undefined;
+      const task = (event.input as Record<string, unknown>).task as string | undefined;
+
+      if (agent && task) {
+        // Phase order validation
+        const phaseResult = validatePhaseOrder({
+          agentType: agent,
+          prompt: task,
+        });
+        if (phaseResult.kind === "block") {
+          return { block: true, reason: phaseResult.message };
+        }
+
+        // Template substitution check
+        const templateResult = validateTemplateSubstitution(task);
+        if (templateResult.kind === "block") {
+          return { block: true, reason: templateResult.message };
+        }
+
+        // Task execution validation (wave order, deps, review gates)
+        const taskResult = await validateTaskExecution({
+          prompt: task,
+          description: (event.input as Record<string, unknown>).description as string ?? "",
+        });
+        if (taskResult.kind === "block") {
+          return { block: true, reason: taskResult.message };
+        }
+
+        // Mark subagent active (equivalent of SubagentStart hook)
+        try {
+          mkdirSync(SUBAGENT_DIR, { recursive: true, mode: 0o700 });
+          appendFileSync(`${SUBAGENT_DIR}/${sessionId}.active`, `${agent}\n`);
+          if (existsSync(TASK_GRAPH_PATH)) {
+            const taskGraphFile = `${SUBAGENT_DIR}/${sessionId}.task_graph`;
+            if (!existsSync(taskGraphFile)) {
+              writeFileSync(taskGraphFile, resolve(TASK_GRAPH_PATH));
+            }
+          }
+        } catch {}
+      }
+    }
+  });
+
+  // ─── Session Lifecycle ────────────────────────────────────────────────
+
+  pi.on("session_start", async (_event, ctx) => {
+    // Cleanup stale subagent tracking files (> 60 min old)
+    if (existsSync(SUBAGENT_DIR)) {
+      const cutoff = Date.now() - 60 * 60_000;
+      try {
+        const { statSync, unlinkSync } = await import("node:fs");
+        for (const entry of readdirSync(SUBAGENT_DIR)) {
+          const path = join(SUBAGENT_DIR, entry);
+          try {
+            if (statSync(path).mtimeMs < cutoff) unlinkSync(path);
+          } catch {}
+        }
+      } catch {}
+    }
+  });
+
+  // ─── Resume Context (before_agent_start) ──────────────────────────────
+  // If there's an active task graph in execute phase, inject context
+  // so the LLM knows where we are (equivalent of resume-after-clear).
+
+  pi.on("before_agent_start", async (_event, _ctx) => {
+    if (!existsSync(TASK_GRAPH_PATH)) return;
+
+    const sm = StateManager.fromPath(TASK_GRAPH_PATH);
+    if (!sm) return;
+
+    let state;
+    try {
+      state = sm.load();
+    } catch {
+      return;
+    }
+
+    if (state.current_phase !== "execute" || state.tasks.length === 0) return;
+
+    const output = buildContextOutput(state, PACKAGE_ROOT);
+    return {
+      message: {
+        customType: "loom-context",
+        content: output,
+        display: false,
+      },
+    };
+  });
+
+  // ─── SubagentStop Dispatch (tool_result event) ────────────────────────
+  // When a subagent completes, handle phase advancement, task status
+  // updates, and review findings — equivalent of SubagentStop hooks.
+
+  pi.on("tool_result", async (event, _ctx) => {
+    if (event.toolName !== "subagent") return;
+
+    const details = event.details as Record<string, unknown> | undefined;
+    if (!details) return;
+
+    const results = (details.results ?? []) as Array<{
+      agent: string;
+      task: string;
+      exitCode: number;
+      messages: unknown[];
+    }>;
+
+    for (const result of results) {
+      const agentType = stripNamespace(result.agent);
+      const sessionId = _ctx.sessionManager.getSessionId() ?? "unknown";
+
+      // Cleanup subagent flag
+      try {
+        const activeFile = `${SUBAGENT_DIR}/${sessionId}.active`;
+        if (existsSync(activeFile)) unlinkSync(activeFile);
+      } catch {}
+
+      const mgr = StateManager.fromSession(sessionId);
+      if (!mgr) continue;
+
+      // --- Phase agent → advance phase ---
+      const completedPhase = PHASE_AGENT_MAP[agentType];
+      if (completedPhase) {
+        const state = mgr.load();
+        const currentIdx = PHASE_ORDER.indexOf(state.current_phase);
+        const completedIdx = PHASE_ORDER.indexOf(completedPhase);
+
+        if (!(completedIdx >= 0 && currentIdx > completedIdx)) {
+          const transition = resolveTransition(completedPhase, state);
+          if (transition) {
+            try {
+              await mgr.update((s) => ({
+                ...s,
+                current_phase: transition.nextPhase,
+                phase_artifacts: { ...s.phase_artifacts, [completedPhase]: transition.artifact },
+                skipped_phases: transition.skipClarify
+                  ? ([...new Set([...s.skipped_phases, "clarify" as const])])
+                  : s.skipped_phases,
+                updated_at: new Date().toISOString(),
+              }));
+            } catch {}
+          }
+        }
+        continue;
+      }
+
+      // --- Impl agent → update task status ---
+      if (IMPL_AGENTS.has(agentType)) {
+        // Get transcript text from subagent result content
+        const transcriptText = event.content
+          .filter((c: { type: string }) => c.type === "text")
+          .map((c: { type: string; text?: string }) => c.text ?? "")
+          .join("\n");
+
+        const taskId = extractTaskId(transcriptText);
+        if (!taskId) continue;
+
+        const state = mgr.load();
+        const task = state.tasks.find((t) => t.id === taskId);
+        if (!task || task.status === "completed" || task.tests_passed === true) continue;
+
+        const bashOutput = parseBashTestOutput(transcriptText);
+        const testEvidence = extractTestEvidence(bashOutput);
+
+        let newTestEvidence = { written: false, evidence: "" };
+        if (git.isGitRepo() && task.start_sha) {
+          const diff = git.diff(task.start_sha, "HEAD");
+          newTestEvidence = analyzeNewTests(diff, task.new_tests_required);
+        }
+
+        await mgr.update((s) => ({
+          ...s,
+          tasks: s.tasks.map((t) =>
+            t.id === taskId
+              ? {
+                  ...t,
+                  status: "implemented" as const,
+                  tests_passed: testEvidence.passed,
+                  test_evidence: testEvidence.evidence,
+                  new_tests_written: newTestEvidence.written,
+                  new_test_evidence: newTestEvidence.evidence,
+                }
+              : t
+          ),
+          executing_tasks: (s.executing_tasks ?? []).filter((id) => id !== taskId),
+        }));
+
+        // Check wave completion
+        const updated = mgr.load();
+        const currentWave = updated.current_wave ?? 1;
+        const waveComplete = !updated.tasks
+          .filter((t) => t.wave === currentWave)
+          .some((t) => t.status !== "implemented" && t.status !== "completed");
+
+        if (waveComplete) {
+          await mgr.update((s) => ({
+            ...s,
+            wave_gates: {
+              ...s.wave_gates,
+              [String(currentWave)]: {
+                ...(s.wave_gates[String(currentWave)] ?? { impl_complete: false, tests_passed: null, reviews_complete: false, blocked: false }),
+                impl_complete: true,
+              },
+            },
+          }));
+        }
+        continue;
+      }
+
+      // --- Review agent → store findings ---
+      if (isReviewAgent(agentType)) {
+        const transcriptText = event.content
+          .filter((c: { type: string }) => c.type === "text")
+          .map((c: { type: string; text?: string }) => c.text ?? "")
+          .join("\n");
+
+        const taskId = extractTaskId(transcriptText);
+        if (!taskId) continue;
+
+        const findings = parseMachineSummary(transcriptText) ?? parseLegacyFindings(transcriptText);
+
+        if (findings.criticalCount === null) {
+          const errorMsg = buildEvidenceFailureMessage(findings);
+          await mgr.update((s) => ({
+            ...s,
+            tasks: s.tasks.map((t) =>
+              t.id === taskId
+                ? { ...t, review_status: "evidence_capture_failed" as const, review_error: errorMsg }
+                : t
+            ),
+          }));
+          continue;
+        }
+
+        const reconciled = reconcileFindings(findings);
+        await mgr.update((s) => ({
+          ...s,
+          tasks: s.tasks.map((t) => t.id === taskId ? mergeFindings(t, reconciled) : t),
+        }));
+        continue;
+      }
+
+      // --- Spec-check invoker → store spec-check findings ---
+      if (agentType === "spec-check-invoker") {
+        const transcriptText = event.content
+          .filter((c: { type: string }) => c.type === "text")
+          .map((c: { type: string; text?: string }) => c.text ?? "")
+          .join("\n");
+
+        const findings = parseSpecCheckOutput(transcriptText);
+        const state = mgr.load();
+        const wave = findings.wave ?? state.current_wave ?? 1;
+
+        if (findings.criticalCount === null) {
+          await mgr.update((s) => ({
+            ...s,
+            spec_check: {
+              wave,
+              run_at: new Date().toISOString(),
+              verdict: "EVIDENCE_CAPTURE_FAILED",
+              error: "SPEC_CHECK_CRITICAL_COUNT marker not found - re-run /wave-gate",
+            },
+          }));
+          continue;
+        }
+
+        const specCheck: SpecCheck = {
+          wave,
+          run_at: new Date().toISOString(),
+          critical_count: findings.criticalCount,
+          high_count: findings.highCount ?? 0,
+          critical_findings: findings.critical,
+          high_findings: findings.high,
+          medium_findings: findings.medium,
+          verdict: findings.verdict ?? "UNKNOWN",
+        };
+
+        await mgr.update((s) => {
+          const updated = { ...s, spec_check: specCheck };
+          if (findings.criticalCount! > 0) {
+            const waveKey = String(wave);
+            updated.wave_gates = {
+              ...s.wave_gates,
+              [waveKey]: {
+                ...(s.wave_gates[waveKey] ?? { impl_complete: false, tests_passed: null, reviews_complete: false, blocked: false }),
+                blocked: true,
+              },
+            };
+          }
+          return updated;
+        });
+        continue;
+      }
+    }
+  });
+
+  // ─── Commands ─────────────────────────────────────────────────────────
+
+  pi.registerCommand("loom-status", {
+    description: "Show current loom orchestration status",
+    handler: async (_args, ctx) => {
+      if (!existsSync(TASK_GRAPH_PATH)) {
+        ctx.ui.notify("No active loom orchestration", "info");
+        return;
+      }
+
+      const sm = StateManager.fromPath(TASK_GRAPH_PATH);
+      if (!sm) {
+        ctx.ui.notify("Could not load task graph", "error");
+        return;
+      }
+
+      try {
+        const state = sm.load();
+        const totalTasks = state.tasks.length;
+        const completed = state.tasks.filter(t => t.status === "completed").length;
+        const failed = state.tasks.filter(t => t.status === "failed").length;
+        const pending = state.tasks.filter(t => t.status === "pending").length;
+
+        ctx.ui.notify(
+          [
+            `Phase: ${state.current_phase}`,
+            `Wave: ${state.current_wave ?? 1}`,
+            `Tasks: ${completed}/${totalTasks} done, ${pending} pending, ${failed} failed`,
+            state.github_issue ? `Issue: #${state.github_issue}` : "",
+          ].filter(Boolean).join(" | "),
+          "info",
+        );
+      } catch (e) {
+        ctx.ui.notify(`Error: ${(e as Error).message}`, "error");
+      }
+    },
+  });
+}

--- a/references/design-functional-evaluator.md
+++ b/references/design-functional-evaluator.md
@@ -1,0 +1,217 @@
+# Functional Evaluator — Universal Build-and-Run Verification
+
+> Design doc — not yet implemented. Inspired by [Anthropic's harness design article](https://www.anthropic.com/engineering/harness-design-long-running-apps).
+
+## Problem
+
+Loom's current evaluators all operate by **reading code**:
+- `spec-check` verifies FR alignment by reading source files
+- `code-reviewer` checks quality/patterns by reading source files
+- `silent-failure-hunter`, `pr-test-analyzer`, `type-design-analyzer`, `comment-analyzer` — all static
+
+None of them answer: **"does the built artifact actually work?"**
+
+You can pass every static reviewer and still have broken functionality — wrong API endpoint wiring, a state machine that deadlocks, stubbed-out methods that compile but do nothing. The article specifically calls out catching "stubbed-out functionality" via live testing.
+
+## Core idea
+
+Add a functional evaluator that **builds the project and exercises its behavior** against the spec's acceptance scenarios. Universality comes from the LLM's ability to adapt to any project type — not from hardcoded project-type logic.
+
+## Architecture: Mirror the spec-check pattern
+
+The functional evaluator follows the same per-wave, own-state, own-gate-check pattern as `spec-check-invoker`. This is the cleanest fit because:
+- Functional tests often span multiple tasks (T1 creates model, T2 creates endpoint — you test via the endpoint)
+- Building the project should happen once per wave, not once per task
+- The infrastructure already has this exact pattern proven
+
+```
+                     wave-gate skill
+                          |
+         +----------------+-----------------+
+         |                |                 |
+   spec-check       functional-check    review agents
+   (per-wave)        (per-wave)         (per-task × 5)
+         |                |                 |
+   store-spec-check  store-functional-  store-reviewer-
+   -findings.ts      check-findings.ts  findings.ts
+         |                |                 |
+         +-------+--------+--------+-------+
+                 |                  |
+           complete-wave-gate (6 checks now)
+```
+
+## Changes required
+
+### 1. New type: `FunctionalCheck` — `engine/src/types.ts`
+
+```typescript
+export interface FunctionalCheck {
+  wave: number;
+  run_at: string;
+  critical_count?: number;
+  critical_findings?: string[];
+  advisory_findings?: string[];
+  verdict: string;  // "PASSED" | "BLOCKED" | "SKIPPED" | "EVIDENCE_CAPTURE_FAILED"
+  error?: string;
+  build_output?: string;  // truncated build log on failure
+}
+```
+
+Add `functional_check?: FunctionalCheck` to `TaskGraph`.
+
+### 2. New agent: `agents/functional-evaluator.md`
+
+```yaml
+---
+name: functional-evaluator
+model: sonnet
+tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+skills:
+  - functional-check
+---
+```
+
+Key agent instructions:
+- Read CLAUDE.md / package.json / pom.xml / Cargo.toml / Makefile to figure out build/run commands
+- Build the project first (build failure = CRITICAL)
+- For each acceptance scenario: write and execute a verification via Bash
+- For APIs: start server in background, curl endpoints, kill server
+- For CLIs: run with test inputs, check output
+- For libraries: `node -e` / `bun -e` / `python -c` inline scripts that import and call
+- For services: start, exercise, stop
+- If project type is unrecognizable or not runnable: emit `FUNCTIONAL_CHECK_VERDICT: SKIPPED`
+
+### 3. New skill: `commands/functional-check.md`
+
+Structured 5-step process (mirrors spec-check's determinism):
+
+1. **Load artifacts** — spec, wave tasks, acceptance scenarios (Given/When/Then)
+2. **Detect project** — read CLAUDE.md for build/run commands; fall back to detecting package.json/pom.xml/Cargo.toml/Makefile
+3. **Build** — run build command. If fails: CRITICAL finding, skip remaining steps
+4. **Verify scenarios** — for each acceptance scenario in scope for this wave:
+   - Translate to executable verification (the LLM figures out *how* based on project type)
+   - Execute via Bash
+   - Emit per-scenario verdict: `PASS` / `FAIL — <reason>`
+5. **Report** — machine-readable footer:
+   ```
+   FUNCTIONAL_CHECK_WAVE: N
+   CRITICAL: Build failed — exit code 1, missing dependency X
+   CRITICAL: POST /api/users returns 500, expected 201
+   ADVISORY: GET /api/health responds in 3.2s (may indicate perf issue)
+   FUNCTIONAL_CHECK_CRITICAL_COUNT: 2
+   FUNCTIONAL_CHECK_VERDICT: BLOCKED
+   ```
+
+### 4. New dispatch category — `engine/src/handlers/subagent-stop/dispatch.ts`
+
+Add `"functional-check"` to `AgentCategory` union:
+
+```typescript
+type AgentCategory = "phase" | "impl" | "review" | "spec-check" | "functional-check" | "unknown";
+```
+
+In `categorize()`:
+```typescript
+if (agentType === "functional-evaluator") return "functional-check";
+```
+
+In the `match()`: route to `storeFunctionalCheckFindings`.
+
+### 5. New SubagentStop handler: `engine/src/handlers/subagent-stop/store-functional-check-findings.ts`
+
+Near-copy of `store-spec-check-findings.ts` but parsing `FUNCTIONAL_CHECK_*` markers instead of `SPEC_CHECK_*`. Stores into `state.functional_check`.
+
+Special handling for `SKIPPED` verdict: treat as non-blocking (don't set `wave_gates[wave].blocked = true`).
+
+### 6. New gate check — `engine/src/handlers/helpers/complete-wave-gate.ts`
+
+Add `checkFunctionalCheck(state, wave)` — mirrors `checkSpecAlignment()`:
+
+```typescript
+export function checkFunctionalCheck(state: TaskGraph, wave: number): GateCheck {
+  if (!state.functional_check) {
+    return { passed: true, message: "5. Functional check: skipped (no data)." };
+  }
+  if (state.functional_check.verdict === "SKIPPED") {
+    return { passed: true, message: "5. Functional check: skipped (project not runnable)." };
+  }
+  if (state.functional_check.wave !== wave) {
+    return { passed: false, message: `FAILED: Functional check ran for wave ${state.functional_check.wave}, not ${wave}.` };
+  }
+  if ((state.functional_check.critical_count ?? 0) > 0) {
+    const findings = (state.functional_check.critical_findings ?? []).map(f => `  - ${f}`).join("\n");
+    return { passed: false, message: `FAILED: Functional check has ${state.functional_check.critical_count} critical findings.\n${findings}` };
+  }
+  return { passed: true, message: `5. Functional check verified (verdict: ${state.functional_check.verdict}).` };
+}
+```
+
+### 7. Config updates — `engine/src/config.ts`
+
+- Add `"functional-evaluator"` to `REVIEW_AGENTS` set (recognized as execute-phase agent)
+- Do NOT add to `REVIEW_SUB_AGENTS` (it's not a per-task reviewer)
+
+### 8. Wave-gate skill update — `commands/wave-gate.md`
+
+Add functional-evaluator spawn alongside spec-check in Step 3 (single message, parallel).
+
+### 9. GitHub issue summary — `complete-wave-gate.ts`
+
+Add functional check results to `generateWaveGateSummary()` output.
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `engine/src/types.ts` | Add `FunctionalCheck` interface, add to `TaskGraph` |
+| `engine/src/config.ts` | Add `"functional-evaluator"` to `REVIEW_AGENTS` |
+| `engine/src/handlers/subagent-stop/dispatch.ts` | New category + route |
+| `engine/src/handlers/subagent-stop/store-functional-check-findings.ts` | **New file** |
+| `engine/src/handlers/helpers/complete-wave-gate.ts` | Add `checkFunctionalCheck()` |
+| `agents/functional-evaluator.md` | **New file** |
+| `commands/functional-check.md` | **New file** |
+| `commands/wave-gate.md` | Add to spawn list |
+
+## What makes it universal (no project-type hardcoding)
+
+The agent reads context clues to figure out how to build and verify:
+
+| Signal | What it tells the agent |
+|---|---|
+| `CLAUDE.md` | Build commands, run commands, project conventions |
+| `package.json` | Node/TS project — `npm run build`, `npm start` |
+| `pom.xml` / `build.gradle` | Java project — `mvn package`, `java -jar` |
+| `Cargo.toml` | Rust — `cargo build`, `./target/debug/binary` |
+| `Makefile` | Generic — `make build`, `make run` |
+| Acceptance scenarios | What behavior to verify |
+
+The LLM adapts its verification approach. No switch statements, no project type enums.
+
+## Graceful degradation
+
+- No build command found → `FUNCTIONAL_CHECK_VERDICT: SKIPPED` → gate passes
+- Build succeeds but no acceptance scenarios → `SKIPPED`
+- Build fails → `CRITICAL` → gate blocks
+- Scenario verification fails → `CRITICAL` → gate blocks
+- Agent output malformed → `EVIDENCE_CAPTURE_FAILED` (same as spec-check)
+
+## Relationship to spec-check
+
+Spec-check and functional-check are complementary, not overlapping:
+
+| | Spec-check | Functional-check |
+|---|---|---|
+| Question | Does the code match the spec? | Does the code actually work? |
+| Method | Reads source files | Builds and runs the artifact |
+| Catches | Missing implementations, scope creep, terminology drift | Runtime failures, integration bugs, stubbed functionality |
+| Medium | Static analysis | Dynamic execution |
+
+## Open questions
+
+- Should the functional evaluator also verify that **existing functionality** still works (regression), or only new acceptance scenarios?
+- Should there be a way for projects to declare a `functional_check.run_command` in CLAUDE.md to short-circuit the detection step?
+- Should the evaluator have a time budget (e.g., 5 min max) to prevent runaway server starts?


### PR DESCRIPTION
## Summary

Adds compatibility with the pi coding agent harness alongside existing Claude Code support.

### Changes
- **Harness detection** via `PI_CODING_AGENT_DIR` env var
- **Configurable state path** — uses `.pi/state/` when running under pi, `.claude/state/` otherwise
- **Pi transcript parsing** — supports pi's JSONL format for tool calls and messages
- **Pre-tool-use handlers** adapted for pi's tool naming conventions (`write`, `edit` vs Claude's longer names)
- **Env overrides** — `LOOM_STATE_PATH` and `LOOM_SUBAGENT_DIR` for explicit configuration