### PR TITLE
feat(agents): inline + enforce architecture/language rules for impl agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "loom",
       "description": "Loom orchestration system - multi-phase task decomposition with wave-based parallel execution",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": { "name": "peterstorm" },
       "source": ".",
       "category": "development"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loom",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Loom orchestration system - multi-phase task decomposition with wave-based parallel execution",
   "author": { "name": "peterstorm" }
 }

--- a/commands/loom.md
+++ b/commands/loom.md
@@ -369,6 +369,7 @@ Substitute variables:
 - `{plan_context}` - Relevant section from plan
 - `{file_list}` - Files to create/modify
 - `{plan_file_path}` - Path to full plan
+- `{rules_content}` - **Inline the binding rules (do NOT leave a file path).** Read `{LOOM_DIR}/rules/architecture.md` (always) plus the stack-specific file(s) — `typescript-patterns.md` for TypeScript/Next.js, `java-patterns.md` + `property-testing.md` for Java, `rust-patterns.md` for Rust — and substitute their full concatenated contents here. The `validate-template-substitution` hook blocks the spawn if `{rules_content}` is left unsubstituted. For docs/config-only tasks (e.g. ADR writing) substitute the literal text `N/A — no code in this task.`
 
 **Spawn implementation agent** with the substituted template as prompt.
 

--- a/commands/templates/impl-agent-context.md
+++ b/commands/templates/impl-agent-context.md
@@ -24,6 +24,14 @@ Writing tests without executing them counts as failure.
 
 ---
 
+## Architecture & Language Rules — BINDING
+
+The project's architecture and language-pattern rules are inlined below. They are NOT optional and NOT "read later" — they are binding constraints for this codebase. Apply them to every file you write or modify. The wave-gate review agents (code-reviewer, type-design-analyzer) enforce them, and violations block the wave.
+
+{rules_content}
+
+---
+
 ## Task Assignment
 
 **Task ID:** {task_id}
@@ -69,8 +77,9 @@ Available at: {plan_file_path}
 
 ## Required Workflow
 
-1. Read the plan file and understand scope
-2. Implement code following the plan's patterns
-3. Write NEW tests (hook git-diffs for @Test, it(, test(, describe( patterns — no new tests = wave blocked) — **skip for docs/config-only tasks where `new_tests_required: false`**
-4. **Run tests via Bash tool** — fix failures, re-run until 0 failures — **skip for docs/config-only tasks**
-5. Only then are you done
+1. Read & apply the **Architecture & Language Rules** inlined above — binding constraints, not suggestions
+2. Read the plan file and understand scope
+3. Implement code following the plan's patterns AND the rules above
+4. Write NEW tests (hook git-diffs for @Test, it(, test(, describe( patterns — no new tests = wave blocked) — **skip for docs/config-only tasks where `new_tests_required: false`**
+5. **Run tests via Bash tool** — fix failures, re-run until 0 failures — **skip for docs/config-only tasks**
+6. Only then are you done

--- a/skills/code-implementer/SKILL.md
+++ b/skills/code-implementer/SKILL.md
@@ -12,7 +12,7 @@ Expert implementation guidance ensuring code follows FP principles, DDD patterns
 
 ## Context Loading
 
-Before implementing, load the relevant rules. Read ONLY what's needed for the target stack:
+Before implementing, you **MUST** read and apply the relevant rules — these are binding constraints, not optional references. Read what's needed for the target stack:
 
 **Always read:**
 - `${CLAUDE_PLUGIN_ROOT}/rules/architecture.md` — core principles (FC/IS, DDD, immutability, testability)
@@ -27,7 +27,7 @@ Before implementing, load the relevant rules. Read ONLY what's needed for the ta
 **Rust** (if implementing Rust):
 - `${CLAUDE_PLUGIN_ROOT}/rules/rust-patterns.md` — newtype, typestate, Result combinators
 
-Apply loaded rules as constraints during implementation.
+Apply loaded rules as binding constraints during implementation. Code that violates them is rejected at the wave gate.
 
 ---
 

--- a/skills/security-expert/SKILL.md
+++ b/skills/security-expert/SKILL.md
@@ -8,6 +8,14 @@ description: "This skill should be used when the user asks to 'secure my API', '
 
 Expert guidance for API security, authentication, authorization, and identity management.
 
+## Context Loading (MANDATORY)
+
+When implementing or modifying code (not only advising), you MUST read and apply the binding project rules:
+- `${CLAUDE_PLUGIN_ROOT}/rules/architecture.md` — FC/IS, DDD, immutability, Either-based errors, ports at I/O boundaries (always)
+- `${CLAUDE_PLUGIN_ROOT}/rules/typescript-patterns.md` (TypeScript) or `${CLAUDE_PLUGIN_ROOT}/rules/java-patterns.md` (Java) — language patterns
+
+These constrain how security-sensitive code is structured; the wave-gate review agents enforce them.
+
 ## Reference Routing
 
 Load the reference that matches the user's problem:

--- a/skills/ts-test-engineer/SKILL.md
+++ b/skills/ts-test-engineer/SKILL.md
@@ -8,6 +8,14 @@ description: "This skill should be used when the user asks to 'write unit tests'
 
 Expert guidance for writing, reviewing, and fixing tests in TypeScript/Next.js applications.
 
+## Context Loading (MANDATORY)
+
+Before writing tests, you MUST read and apply the binding project rules:
+- `${CLAUDE_PLUGIN_ROOT}/rules/architecture.md` — FC/IS, DDD, immutability, testability (always)
+- `${CLAUDE_PLUGIN_ROOT}/rules/typescript-patterns.md` — discriminated unions, branded types, ts-pattern, ports & in-memory fakes
+
+These are not optional. Tests must exercise the functional core without mocks and follow the port/fake patterns described there.
+
 ---
 
 ## Workflow


### PR DESCRIPTION
## Problem

Loom's implementation/test/security agents are supposed to follow the architecture + language rules in `rules/*.md`, but they receive them only via a soft "go read these files" pointer in a preloaded skill. In a real run this proved unreliable: **4/4 implementation agents had the `code-implementer` skill loaded yet read zero `rules/*.md` files**. Two skills (`ts-test-engineer`, `security-expert`) did not reference the rules at all.

## What changed (7 files)

- **`commands/templates/impl-agent-context.md`** — new binding `## Architecture & Language Rules — BINDING` section with a `{rules_content}` placeholder, inserted before `## Task Assignment`. Required Workflow updated to make applying the inlined rules step 1.
- **`commands/loom.md`** — documents the `{rules_content}` substitution in the Phase 5 spawn variable list (inline the concatenated `architecture.md` + stack-specific rule files; `N/A — no code in this task.` for docs/config-only tasks).
- **`skills/ts-test-engineer/SKILL.md`** — adds a `## Context Loading (MANDATORY)` section (previously had no rules reference).
- **`skills/security-expert/SKILL.md`** — adds a `## Context Loading (MANDATORY)` section (previously had no rules reference).
- **`skills/code-implementer/SKILL.md`** — hardens the rules pointer from a soft "load the relevant rules" to a MUST-read binding constraint, with wave-gate rejection noted.
- **`.claude-plugin/plugin.json`** + **`.claude-plugin/marketplace.json`** — version bump `1.0.2` -> `1.0.3`.

## How it's enforced

Instead of relying on agents to follow a pointer, the orchestrator now **inlines the full rules content** directly into each implementation agent's spawn prompt. The `validate-template-substitution` hook blocks the spawn if `{rules_content}` is left unsubstituted, so an agent cannot be spawned without the rules present in its context. The wave-gate review agents (code-reviewer, type-design-analyzer) continue to enforce the rules at review time.

## Possible follow-up

Add a `SubagentStop` hook that verifies the rules were actually *applied* (not just present in context) — e.g. by checking that the implementation agent's diff conforms to key structural invariants (functional core / imperative shell separation, Either-based error handling) before allowing the subagent to stop. This would close the loop from "rules are in context" to "rules were followed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)